### PR TITLE
mb/starlabs/starbook: Configure RPL GPP_D5 as NC

### DIFF
--- a/src/mainboard/starlabs/starbook/variants/rpl/gpio.c
+++ b/src/mainboard/starlabs/starbook/variants/rpl/gpio.c
@@ -208,7 +208,7 @@ const struct pad_config gpio_table[] = {
 	PAD_NC(GPP_D2, NONE),
 	PAD_NC(GPP_D3, NONE),
 	PAD_NC(GPP_D4, NONE),
-	PAD_NC(GPP_D3, NONE),
+	PAD_NC(GPP_D5, NONE),
 	PAD_NC(GPP_D6, NONE),
 	PAD_NC(GPP_D8, NONE),
 	PAD_NC(GPP_D9, NONE),


### PR DESCRIPTION
## Summary

- Replace the duplicated `GPP_D3` NC entry in the StarBook RPL GPIO table with `GPP_D5`.
- This avoids configuring `GPP_D3` twice while leaving `GPP_D5` unconfigured.
- The resulting sequence matches the neighbouring StarBook ADL GPIO table and the StarFighter RPL GPIO table pattern.

## Context

This was noticed while looking into the symptoms reported in StarLabsLtd/firmware#440.

I didn't verified this change on the affected hardware yet. This PR is based on static code review only, so it should be treated as a likely GPIO table typo rather than a confirmed fix for that issue.

## Testing

- `git diff --check`
- Static inspection of `gpio_table[]`: no duplicate pads in the table after the change, and `GPP_D5` is now configured as NC.
- Not tested on affected hardware.
