### PR TITLE
ec/starlabs/merlin: align ITE option fallbacks

### DIFF
--- a/src/ec/starlabs/merlin/ite.c
+++ b/src/ec/starlabs/merlin/ite.c
@@ -137,7 +137,7 @@ static void merlin_restore_options(void *unused)
 
 	ec_write(ECRAM_FN_LOCK_STATE,
 		 get_ec_value_from_option(
-			 "fn_lock_state", UNLOCKED, fn_lock_state, ARRAY_SIZE(fn_lock_state)));
+			 "fn_lock_state", LOCKED, fn_lock_state, ARRAY_SIZE(fn_lock_state)));
 
 	/*
 	 * Trackpad State
@@ -195,14 +195,14 @@ static void merlin_restore_options(void *unused)
 	 * Setting:	charging_speed
 	 *
 	 * Values:	1.0C, 0.5C, 0.2C
-	 * Default:	0.5C
+	 * Default:	1.0C
 	 *
 	 */
 	const uint8_t charging_speed[] = {SPEED_1_0C, SPEED_0_5C, SPEED_0_2C};
 
 	if (CONFIG(EC_STARLABS_CHARGING_SPEED))
 		ec_write(ECRAM_CHARGING_SPEED,
-			 get_ec_value_from_option("charging_speed", SPEED_0_5C, charging_speed,
+			 get_ec_value_from_option("charging_speed", SPEED_1_0C, charging_speed,
 						  ARRAY_SIZE(charging_speed)));
 
 	/*


### PR DESCRIPTION
This came out of investigating my StarBook MkVIr2 firmware issue:

- https://github.com/StarLabsLtd/firmware/issues/440

`merlin_restore_options()` runs in coreboot at `BS_DEV_INIT`, before the EDK2 CFR setup driver can create missing EFI option variables in SMMSTORE. On a blank/recovered option store, `get_uint_option()` therefore returns the hard-coded fallback and that value is written directly to EC RAM.

For ITE EC restore the fallbacks for two options did not match the advertised/default CFR values:

- `fn_lock_state`: comment/CFR/SMI default is `LOCKED`, but restore fallback was `UNLOCKED`
- `charging_speed`: CFR default is `SPEED_1_0C`, but restore fallback was `SPEED_0_5C`

That means first boot after an external full flash or SMMSTORE recovery can briefly/programmatically apply different EC-visible defaults from the ones EDK2 will later create. If the machine does not reach EDK2 on that path, the missing-variable fallback can be hit repeatedly.

This PR aligns the ITE restore fallbacks with the CFR defaults.

Notes:

- This is related to my investigation in StarLabsLtd/firmware#440.
- I have not yet hardware-tested this on the affected machine; this is based on code-path review.
- I noticed an equivalent fix also exists on the `codex/26.07-merlin-persistent-auto-on` branch, but not on `26.06`.

Tested:

- `git diff --check`
