### PR TITLE
soc/intel: Configure TCSS AUX orientation per port

### DIFF
--- a/src/soc/intel/alderlake/fsp_params.c
+++ b/src/soc/intel/alderlake/fsp_params.c
@@ -635,6 +635,15 @@ static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,
 	};
 
 	s_cfg->TcssAuxOri = config->tcss_aux_ori;
+	for (int i = 0; i < MAX_TYPE_C_PORTS; i++) {
+		const struct tcss_port_config *port = &config->tcss_ports[i];
+
+		if (!port->enable || !port->aux_orientation_set)
+			continue;
+
+		s_cfg->TcssAuxOri = tcss_apply_aux_orientation(s_cfg->TcssAuxOri, i,
+							      port->aux_orientation);
+	}
 
 	/* Explicitly clear this field to avoid using defaults */
 	memset(s_cfg->IomTypeCPortPadCfg, 0, sizeof(s_cfg->IomTypeCPortPadCfg));

--- a/src/soc/intel/alderlake/include/soc/usb.h
+++ b/src/soc/intel/alderlake/include/soc/usb.h
@@ -167,7 +167,10 @@ struct usb3_port_config {
 }
 
 struct tcss_port_config {
-	uint8_t enable;
+	uint8_t enable:1;
+	uint8_t aux_orientation_set:1;
+	uint8_t aux_orientation:2;
+	uint8_t reserved:4;
 	uint8_t ocpin;
 };
 
@@ -179,6 +182,13 @@ struct tcss_port_config {
 #define TCSS_PORT_DEFAULT(pin) { \
 	.enable           = 1, \
 	.ocpin            = (pin), \
+}
+
+#define TCSS_PORT_DEFAULT_AUX(pin, orientation) { \
+	.enable               = 1, \
+	.ocpin                = (pin), \
+	.aux_orientation      = (orientation), \
+	.aux_orientation_set  = 1, \
 }
 
 #endif

--- a/src/soc/intel/common/block/include/intelblocks/tcss.h
+++ b/src/soc/intel/common/block/include/intelblocks/tcss.h
@@ -6,6 +6,7 @@
 #include <intelblocks/gpio.h>
 #if !defined(__ACPI__)
 #include <device/usbc_mux.h>
+#include <stdint.h>
 
 /* PMC IPC related offsets and commands */
 #define PMC_IPC_USBC_CMD_ID		0xA7
@@ -77,6 +78,44 @@ enum typec_port_index {
 	TYPE_C_PORT_3,
 	MAX_TYPE_C_PORTS,
 };
+
+enum tcss_aux_orientation {
+	/* Do not override AUX orientation in the SoC. */
+	TCSS_AUX_ORIENTATION_NO_OVERRIDE,
+	/* The SoC handles AUX orientation and AUX+ follows CC1. */
+	TCSS_AUX_ORIENTATION_FOLLOW_CC1,
+	/* The SoC handles AUX orientation and AUX+ follows CC2. */
+	TCSS_AUX_ORIENTATION_FOLLOW_CC2,
+};
+
+static inline uint16_t tcss_apply_aux_orientation(uint16_t aux_ori, unsigned int port,
+						  enum tcss_aux_orientation orientation)
+{
+	uint16_t setting;
+	const unsigned int shift = port * 2;
+
+	if (port >= MAX_TYPE_C_PORTS)
+		return aux_ori;
+
+	switch (orientation) {
+	case TCSS_AUX_ORIENTATION_NO_OVERRIDE:
+		setting = 0;
+		break;
+	case TCSS_AUX_ORIENTATION_FOLLOW_CC1:
+		setting = 1;
+		break;
+	case TCSS_AUX_ORIENTATION_FOLLOW_CC2:
+		setting = 3;
+		break;
+	default:
+		return aux_ori;
+	}
+
+	aux_ori &= ~(3 << shift);
+	aux_ori |= setting << shift;
+
+	return aux_ori;
+}
 
 #define TCSS_CD_FIELD(name, val) \
 	(((val) & TCSS_CD_##name##_MASK) << TCSS_CD_##name##_SHIFT)

--- a/src/soc/intel/common/block/include/intelblocks/usb.h
+++ b/src/soc/intel/common/block/include/intelblocks/usb.h
@@ -145,7 +145,10 @@ struct usb3_port_config {
 }
 
 struct tcss_port_config {
-	uint8_t enable;
+	uint8_t enable:1;
+	uint8_t aux_orientation_set:1;
+	uint8_t aux_orientation:2;
+	uint8_t reserved:4;
 	uint8_t ocpin;
 };
 
@@ -157,6 +160,13 @@ struct tcss_port_config {
 #define TCSS_PORT_DEFAULT(pin) { \
 	.enable           = 1, \
 	.ocpin            = (pin), \
+}
+
+#define TCSS_PORT_DEFAULT_AUX(pin, orientation) { \
+	.enable               = 1, \
+	.ocpin                = (pin), \
+	.aux_orientation      = (orientation), \
+	.aux_orientation_set  = 1, \
 }
 
 #endif

--- a/src/soc/intel/meteorlake/fsp_params.c
+++ b/src/soc/intel/meteorlake/fsp_params.c
@@ -394,6 +394,15 @@ static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,
 	};
 
 	s_cfg->TcssAuxOri = config->tcss_aux_ori;
+	for (int i = 0; i < MAX_TYPE_C_PORTS; i++) {
+		const struct tcss_port_config *port = &config->tcss_ports[i];
+
+		if (!port->enable || !port->aux_orientation_set)
+			continue;
+
+		s_cfg->TcssAuxOri = tcss_apply_aux_orientation(s_cfg->TcssAuxOri, i,
+							      port->aux_orientation);
+	}
 
 	/* Explicitly clear this field to avoid using defaults */
 	memset(s_cfg->IomTypeCPortPadCfg, 0, sizeof(s_cfg->IomTypeCPortPadCfg));

--- a/src/soc/intel/pantherlake/fsp_params.c
+++ b/src/soc/intel/pantherlake/fsp_params.c
@@ -317,6 +317,15 @@ static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,
 				  const struct soc_intel_pantherlake_config *config)
 {
 	s_cfg->TcssAuxOri = config->tcss_aux_ori;
+	for (size_t i = 0; i < MAX_TYPE_C_PORTS; i++) {
+		const struct tcss_port_config *port = &config->tcss_ports[i];
+
+		if (!port->enable || !port->aux_orientation_set)
+			continue;
+
+		s_cfg->TcssAuxOri = tcss_apply_aux_orientation(s_cfg->TcssAuxOri, i,
+							      port->aux_orientation);
+	}
 
 	/* Explicitly clear this field to avoid using defaults */
 	memset(s_cfg->IomTypeCPortPadCfg, 0, sizeof(s_cfg->IomTypeCPortPadCfg));

--- a/src/soc/intel/tigerlake/fsp_params.c
+++ b/src/soc/intel/tigerlake/fsp_params.c
@@ -333,6 +333,15 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 
 	params->UsbTcPortEn = config->UsbTcPortEn;
 	params->TcssAuxOri = config->TcssAuxOri;
+	for (i = 0; i < MAX_TYPE_C_PORTS; i++) {
+		const struct tcss_port_config *port = &config->tcss_ports[i];
+
+		if (!port->enable || !port->aux_orientation_set)
+			continue;
+
+		params->TcssAuxOri = tcss_apply_aux_orientation(params->TcssAuxOri, i,
+							       port->aux_orientation);
+	}
 
 	/* Explicitly clear this field to avoid using defaults */
 	memset(params->IomTypeCPortPadCfg, 0, sizeof(params->IomTypeCPortPadCfg));

--- a/src/soc/intel/tigerlake/include/soc/usb.h
+++ b/src/soc/intel/tigerlake/include/soc/usb.h
@@ -138,7 +138,10 @@ struct usb3_port_config {
 }
 
 struct tcss_port_config {
-	uint8_t enable;
+	uint8_t enable:1;
+	uint8_t aux_orientation_set:1;
+	uint8_t aux_orientation:2;
+	uint8_t reserved:4;
 	uint8_t ocpin;
 };
 
@@ -150,6 +153,13 @@ struct tcss_port_config {
 #define TCSS_PORT_DEFAULT(pin) { \
 	.enable           = 1, \
 	.ocpin            = (pin), \
+}
+
+#define TCSS_PORT_DEFAULT_AUX(pin, orientation) { \
+	.enable               = 1, \
+	.ocpin                = (pin), \
+	.aux_orientation      = (orientation), \
+	.aux_orientation_set  = 1, \
 }
 
 #endif


### PR DESCRIPTION
TcssAuxOri is a two-bit field per TCSS port, but board configuration currently uses a raw SoC-wide value separate from tcss_ports[].

Add an opt-in per-port macro and apply selected fields over the legacy raw value. Existing TCSS_PORT_DEFAULT() and TCSS_PORT_EMPTY users leave orientation unset. The bitfield keeps tcss_port_config at two bytes, preserving the previous generated layout.

Validated Tiger Lake, Alder Lake, Meteor Lake and Panther Lake FSP object builds and ACPI compile/disassembly. Base and patched generated SoC data are byte-identical for StarFighter MTL and Protectli VP66xx, including Protectli's raw 0x10 policy.

This is the common API only. Board migrations remain separate.