### PR TITLE
mb/starlabs/starbook: Configure TCSS AUX per port

### DIFF
--- a/src/mainboard/starlabs/starbook/variants/mtl/devicetree.cb
+++ b/src/mainboard/starlabs/starbook/variants/mtl/devicetree.cb
@@ -57,8 +57,6 @@ chip soc/intel/meteorlake
 			}"
 		end
 		device ref tcss_xhci	on
-			register "tcss_aux_ori"			= "(BIT(0) | BIT(2))"
-
 			chip drivers/usb/acpi
 				device ref tcss_root_hub on
 					chip drivers/usb/acpi
@@ -82,11 +80,14 @@ chip soc/intel/meteorlake
 		device ref xhci		on
 			# Motherboard USB 3.0 Type-C Back	7893 mil
 			register "usb2_ports[0]"		= "USB2_PORT_TYPE_C(OC_SKIP)"
-			register "tcss_ports[0]"		= "TCSS_PORT_DEFAULT(OC_SKIP)"
 
 			# Motherboard USB 3.0 Type-C Front	9557 mil
 			register "usb2_ports[2]"		= "USB2_PORT_TYPE_C(OC_SKIP)"
-			register "tcss_ports[1]"		= "TCSS_PORT_DEFAULT(OC_SKIP)"
+
+			register "tcss_ports" = "{
+				[0] = TCSS_PORT_DEFAULT_AUX(OC_SKIP, TCSS_AUX_ORIENTATION_FOLLOW_CC1),
+				[1] = TCSS_PORT_DEFAULT_AUX(OC_SKIP, TCSS_AUX_ORIENTATION_FOLLOW_CC1),
+			}"
 
 			# Motherboard USB 3.0 Type-A		8916 mil
 			register "usb2_ports[1]"		= "USB2_PORT_MID(OC_SKIP)"


### PR DESCRIPTION
B7-U routes TCP0 and TCP1 AUX straight to CCG6DF SBU pass-through switches, so the SoC must follow CC1 for both ports.

Move that policy into tcss_ports[] instead of using the raw TcssAuxOri bitfield. The generated config has both ports enabled with FOLLOW_CC1 and no raw override, producing the same final FSP value of 0x0005.

A payload-disabled StarBook MTL image builds completely. All 11 Star Labs TCSS-capable release configs retain their audited final values.

Depends on #22.