### PR TITLE
payloads: integrate CDK2 as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 	url = https://github.com/openSIL/openSIL.git
 	branch = turin_poc
 
+[submodule "payloads/external/cdk2/cdk2"]
+	path = payloads/external/cdk2/cdk2
+	url = git@github.com:StarLabsLtd/cdk2.git

--- a/Documentation/payloads/cdk2.md
+++ b/Documentation/payloads/cdk2.md
@@ -1,11 +1,11 @@
 # CDK2 payload
 
 CDK2 is built from `payloads/external/cdk2/cdk2` as a coreboot-owned external
-payload. Coreboot passes its resolved configuration, toolchain and output
+payload. coreboot passes its resolved configuration, toolchain and output
 directory to CDK2. CDK2 remains responsible for selecting, compiling, linking
 and testing its own sources.
 
-Coreboot's lint targets intentionally do not inspect files behind a submodule
+coreboot's lint targets intentionally do not inspect files behind a submodule
 gitlink. `test-cdk2` therefore invokes CDK2's `what-jenkins-does` target
 explicitly. `test-cdk2-qemu` additionally builds a Q35 ROM containing that
 exact payload with both the normal 32-bit ramstage and the optional 64-bit

--- a/Documentation/payloads/cdk2.md
+++ b/Documentation/payloads/cdk2.md
@@ -8,7 +8,14 @@ and testing its own sources.
 Coreboot's lint targets intentionally do not inspect files behind a submodule
 gitlink. `test-cdk2` therefore invokes CDK2's `what-jenkins-does` target
 explicitly. `test-cdk2-qemu` additionally builds a Q35 ROM containing that
-exact payload and requires the shell startup and shutdown markers.
+exact payload with both the normal 32-bit ramstage and the optional 64-bit
+ramstage, then requires the shell startup and shutdown markers from each.
+
+CDK2 has a 32-bit protected-mode entry stub because that is the standard x86
+coreboot payload ABI. A 32-bit ramstage calls it directly using cdecl. A 64-bit
+ramstage uses coreboot's protected-mode compatibility call, which presents the
+same stack layout. CDK2 performs its own transition to long mode in both cases;
+`USE_X86_64_SUPPORT` is therefore not a payload requirement.
 
 The QEMU test leaves the linked ROM unchanged, initializes the SMM variable
 store in a test copy with coreboot's `smmstoretool`, verifies that the store is

--- a/Documentation/payloads/cdk2.md
+++ b/Documentation/payloads/cdk2.md
@@ -1,0 +1,27 @@
+# CDK2 payload
+
+CDK2 is built from `payloads/external/cdk2/cdk2` as a coreboot-owned external
+payload. Coreboot passes its resolved configuration, toolchain and output
+directory to CDK2. CDK2 remains responsible for selecting, compiling, linking
+and testing its own sources.
+
+Coreboot's lint targets intentionally do not inspect files behind a submodule
+gitlink. `test-cdk2` therefore invokes CDK2's `what-jenkins-does` target
+explicitly. `test-cdk2-qemu` additionally builds a Q35 ROM containing that
+exact payload and requires the shell startup and shutdown markers.
+
+The QEMU test leaves the linked ROM unchanged, initializes the SMM variable
+store in a test copy with coreboot's `smmstoretool`, verifies that the store is
+empty, and exposes that copy as writable pflash. This models the runtime flash
+contract and avoids depending on a preformatted repository binary.
+
+## Transitional retained firmware volume
+
+Until CDK2's retained-module inventory reaches zero, an integration build must
+set both `CDK2_RETAINED_FV` and `CDK2_RETAINED_FV_SHA256`. The build validates
+the file, its digest and CDK2's inventory before using it. The firmware volume
+is a reviewed build input; it is not stored or silently downloaded by coreboot.
+
+The retained-FV Kconfig options and validation path must be removed when the
+inventory reaches zero. At that point CDK2's coreboot build contract supplies
+the complete payload using only its source tree and coreboot configuration.

--- a/Documentation/util/smmstoretool/index.md
+++ b/Documentation/util/smmstoretool/index.md
@@ -49,6 +49,15 @@ Sub-commands:
 
 Then run `smmstoretool rom help sub-command-name` to get more details.
 
+The `init` subcommand creates an empty variable-store firmware volume when
+the selected SMMSTORE region is erased. It is idempotent: an already valid
+store is left unchanged. This is useful when preparing a writable QEMU pflash
+image before its first boot:
+
+```
+smmstoretool coreboot.rom init
+```
+
 ## Data types
 
 EFI variables in the storage don't have an associated data type and it needs to

--- a/payloads/Kconfig
+++ b/payloads/Kconfig
@@ -59,7 +59,7 @@ source "payloads/external/*/Kconfig"
 
 config PAYLOAD_OWNS_PCI_DEVICES
 	bool
-	default y if PAYLOAD_EDK2
+	default y if PAYLOAD_EDK2 || PAYLOAD_CDK2
 	help
 	  Select this when the payload takes ownership of PCI devices after
 	  coreboot and will enable bus mastering from its own drivers.

--- a/payloads/external/Makefile.mk
+++ b/payloads/external/Makefile.mk
@@ -157,6 +157,54 @@ payloads/external/depthcharge/depthcharge/build/depthcharge.elf depthcharge: $(D
 
 # edk2
 
+# cdk2
+
+ifeq ($(CONFIG_PAYLOAD_CDK2),y)
+CDK2_SOURCE := payloads/external/cdk2/cdk2
+CDK2_PAYLOAD := $(call strip_quotes,$(CONFIG_PAYLOAD_FILE))
+CDK2_OUTPUT := $(patsubst %/native/,%,$(dir $(CDK2_PAYLOAD)))
+CDK2_RETAINED_FV := $(call strip_quotes,$(CONFIG_CDK2_RETAINED_FV))
+CDK2_RETAINED_FV_SHA256 := $(call strip_quotes,$(CONFIG_CDK2_RETAINED_FV_SHA256))
+
+$(CDK2_PAYLOAD): $(DOTCONFIG) $(objutil)/kconfig/conf
+	@test "$(CONFIG_SMMSTORE)" = y || { \
+		echo "CDK2 requires CONFIG_SMMSTORE=y for the coreboot handoff" >&2; \
+		exit 1; \
+	}
+	@test -n "$(CDK2_RETAINED_FV)" || { \
+		echo "CDK2_RETAINED_FV is required until the retained inventory reaches zero" >&2; \
+		exit 1; \
+	}
+	@test -f "$(CDK2_RETAINED_FV)" || { \
+		echo "CDK2 retained FV does not exist: $(CDK2_RETAINED_FV)" >&2; \
+		exit 1; \
+	}
+	@test -n "$(CDK2_RETAINED_FV_SHA256)" || { \
+		echo "CDK2_RETAINED_FV_SHA256 is required" >&2; \
+		exit 1; \
+	}
+	@printf '%s  %s\n' "$(CDK2_RETAINED_FV_SHA256)" "$(CDK2_RETAINED_FV)" | sha256sum -c -
+	+$(MAKE) -C $(CDK2_SOURCE) retained-fv-check native-fvinfo \
+		CDK2_KCONFIG_TOOL="$(abspath $(objutil)/kconfig/conf)" \
+		CDK2_BUILD_DIR="$(abspath $(CDK2_OUTPUT))"
+	+$(MAKE) -C $(CDK2_SOURCE) coreboot-stage \
+		COREBOOT_CONFIG="$(abspath $(DOTCONFIG))" \
+		COREBOOT_OUTPUT_DIR="$(abspath $(CDK2_OUTPUT))" \
+		CDK2_KCONFIG_TOOL="$(abspath $(objutil)/kconfig/conf)" \
+		HOSTCC="$(HOSTCC)" CC=cc \
+		LD=ld OBJCOPY="$(OBJCOPY_x86_64)" \
+		NM="$(NM_x86_64)"
+	+$(MAKE) -C $(CDK2_SOURCE) native-coreboot-image \
+		CDK2_BUILD_DIR="$(abspath $(CDK2_OUTPUT))" \
+		CDK2_CONFIG="$(abspath $(CDK2_OUTPUT))/.config" \
+		CDK2_KCONFIG_TOOL="$(abspath $(objutil)/kconfig/conf)" \
+		CDK2_PAYLOAD_FV="$(abspath $(CDK2_RETAINED_FV))" \
+		HOSTCC="$(HOSTCC)" CC=cc LD=ld \
+		CDK2_NATIVE_OBJCOPY="$(OBJCOPY_x86_64)" \
+		CDK2_NATIVE_NM="$(NM_x86_64)"
+
+endif
+
 ifeq ($(CONFIG_EDK2_ENABLE_IPXE),y)
 IPXE_EFI := payloads/external/iPXE/ipxe/ipxe.rom
 endif

--- a/payloads/external/cdk2/Kconfig
+++ b/payloads/external/cdk2/Kconfig
@@ -1,0 +1,23 @@
+## SPDX-License-Identifier: GPL-2.0-only
+
+if PAYLOAD_CDK2
+
+source "payloads/external/cdk2/cdk2/Kconfig"
+
+config CDK2_RETAINED_FV
+	string "Transitional retained firmware volume"
+	help
+	  Path to the reviewed retained-module firmware volume. This input is
+	  temporary and must be removed when CDK2's retained inventory reaches
+	  zero. The build fails if the file or its expected SHA-256 is absent.
+
+config CDK2_RETAINED_FV_SHA256
+	string "Expected retained firmware-volume SHA-256"
+	depends on CDK2_RETAINED_FV != ""
+	help
+	  Exact lowercase SHA-256 of CDK2_RETAINED_FV.
+
+config PAYLOAD_FILE
+	default "$(obj)/cdk2/native/cdk2-coreboot-image.elf"
+
+endif

--- a/payloads/external/cdk2/Kconfig.name
+++ b/payloads/external/cdk2/Kconfig.name
@@ -3,13 +3,13 @@
 config PAYLOAD_CDK2
 	bool "CDK2"
 	depends on ARCH_X86
-	depends on USE_X86_64_SUPPORT
 	select HANDOFF_COREBOOT_TABLES
 	select WANT_LINEAR_FRAMEBUFFER
 	select SMMSTORE
 	help
 	  Build CDK2 from its source submodule and add its ELF image as the
-	  primary payload. CDK2's 32-bit entry stub requires the protected-mode
-	  payload-call ABI provided by a 64-bit coreboot ramstage. The current
-	  transition also requires coreboot-produced SMMSTORE and linear
-	  framebuffer table records.
+	  primary payload. CDK2's 32-bit entry accepts coreboot's standard cdecl
+	  payload handoff from either a 32-bit ramstage or the protected-mode
+	  compatibility call made by a 64-bit ramstage. The current transition
+	  also requires coreboot-produced SMMSTORE and linear framebuffer table
+	  records.

--- a/payloads/external/cdk2/Kconfig.name
+++ b/payloads/external/cdk2/Kconfig.name
@@ -1,0 +1,15 @@
+## SPDX-License-Identifier: GPL-2.0-only
+
+config PAYLOAD_CDK2
+	bool "CDK2"
+	depends on ARCH_X86
+	depends on USE_X86_64_SUPPORT
+	select HANDOFF_COREBOOT_TABLES
+	select WANT_LINEAR_FRAMEBUFFER
+	select SMMSTORE
+	help
+	  Build CDK2 from its source submodule and add its ELF image as the
+	  primary payload. CDK2's 32-bit entry stub requires the protected-mode
+	  payload-call ABI provided by a 64-bit coreboot ramstage. The current
+	  transition also requires coreboot-produced SMMSTORE and linear
+	  framebuffer table records.

--- a/util/smmstoretool/Makefile
+++ b/util/smmstoretool/Makefile
@@ -38,9 +38,12 @@ SRC += fmap.c kv_pair.c valstr.c
 OBJ := $(SRC:.c=.o)
 DEP := $(SRC:.c=.o.d)
 
-.PHONY: all debug clean install
+.PHONY: all debug clean install test
 
 all: $(PRG)
+
+test: $(PRG)
+	./tests/init-test ./$(PRG)
 
 debug: HOSTCFLAGS += -O0 -g
 debug: HOSTLDFLAGS += -g

--- a/util/smmstoretool/main.c
+++ b/util/smmstoretool/main.c
@@ -26,12 +26,14 @@ struct subcommand_t {
 static void help_get(FILE *f, const struct subcommand_t *info);
 static void help_guids(FILE *f, const struct subcommand_t *info);
 static void help_help(FILE *f, const struct subcommand_t *info);
+static void help_init(FILE *f, const struct subcommand_t *info);
 static void help_list(FILE *f, const struct subcommand_t *info);
 static void help_remove(FILE *f, const struct subcommand_t *info);
 static void help_set(FILE *f, const struct subcommand_t *info);
 static int process_get(int argc, char *argv[], const char store_file[]);
 static int process_guids(int argc, char *argv[], const char store_file[]);
 static int process_help(int argc, char *argv[], const char store_file[]);
+static int process_init(int argc, char *argv[], const char store_file[]);
 static int process_list(int argc, char *argv[], const char store_file[]);
 static int process_remove(int argc, char *argv[], const char store_file[]);
 static int process_set(int argc, char *argv[], const char store_file[]);
@@ -54,6 +56,12 @@ static const struct subcommand_t sub_commands[] = {
 		.description = "provide built-in help",
 		.print_help = &help_help,
 		.process = &process_help,
+	},
+	{
+		.name = "init",
+		.description = "initialize an empty variable store",
+		.print_help = &help_init,
+		.process = &process_init,
 	},
 	{
 		.name = "list",
@@ -130,6 +138,28 @@ static void print_types(FILE *f)
 	fprintf(f, " * unicode (widened and NUL-terminated)\n");
 	fprintf(f, " * file (input only; file contents as variable)\n");
 	fprintf(f, " * raw (output only; raw bytes on output)\n");
+}
+
+static void help_init(FILE *f, const struct subcommand_t *info)
+{
+	fprintf(f, "Initialize an empty variable store if it is not formatted:\n");
+	fprintf(f, "  %s smm-store-file|rom %s\n", program_name, info->name);
+}
+
+static int process_init(int argc, char *argv[], const char store_file[])
+{
+	struct storage_t storage;
+
+	if (argc != 1) {
+		fprintf(stderr, "Invalid invocation\n");
+		print_sub_command_usage(argv[0]);
+	}
+
+	if (!storage_open(store_file, &storage, /*rw=*/true))
+		return EXIT_FAILURE;
+
+	storage_drop(&storage);
+	return EXIT_SUCCESS;
 }
 
 static void help_set(FILE *f, const struct subcommand_t *info)

--- a/util/smmstoretool/tests/init-test
+++ b/util/smmstoretool/tests/init-test
@@ -1,0 +1,19 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -eu
+
+tool=$1
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/smmstoretool-init.XXXXXX")
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+store=$tmpdir/SMMSTORE
+
+dd if=/dev/zero bs=65536 count=8 2>/dev/null | tr '\000' '\377' >"$store"
+"$tool" "$store" init
+test -z "$("$tool" "$store" list)"
+
+sha256sum "$store" >"$tmpdir/before.sha256"
+"$tool" "$store" init
+sha256sum -c "$tmpdir/before.sha256"
+
+printf '%s\n' 'smmstoretool init test: PASS'

--- a/util/testing/Makefile.mk
+++ b/util/testing/Makefile.mk
@@ -6,6 +6,8 @@ test-help help::
 	@echo  '                         Skip tests by setting env vars JENKINS_SKIP_x_TESTS'
 	@echo  '                         to 'y' where x is: CLANG, GCC, LINT, TOOL, or UNIT'
 	@echo  '  lint / lint-stable   - Run coreboot lint tools (all / minimal)'
+	@echo  '  test-cdk2            - Run CDK2-owned checks explicitly'
+	@echo  '  test-cdk2-qemu       - Build and boot the integrated Q35 ROM'
 	@echo  '  test-basic           - Run standard build tests. All expected to pass.'
 	@echo  '  test-lint            - Basic: Run stable and extended lint tests.'
 	@echo  '  test-tools           - Basic: Tests a basic list of tools.'
@@ -92,6 +94,9 @@ validate_sec_tools:
 	fi
 
 what-jenkins-does: test-cleanup validate_sec_tools
+ifneq ($(JENKINS_SKIP_CDK2_TESTS),y)
+	+$(MAKE) test-cdk2 test-cdk2-qemu
+endif
 ifneq ($(JENKINS_SKIP_LINT_TESTS),y)
 	JUNIT=--junit $(MAKE) test-lint
 endif
@@ -110,6 +115,18 @@ ifneq  ($(JENKINS_SKIP_UNIT_TESTS),y)
 endif
 
 test-basic: test-lint test-tools test-abuild test-payloads test-cleanup
+
+test-cdk2: build/util/kconfig/conf
+	@test -f payloads/external/cdk2/cdk2/Makefile || { \
+		echo "CDK2 submodule is not initialized" >&2; \
+		exit 1; \
+	}
+	+$(MAKE) -C payloads/external/cdk2/cdk2 what-jenkins-does \
+		CDK2_KCONFIG_TOOL="$(abspath build/util/kconfig/conf)" \
+		CDK2_NATIVE_CC=cc CDK2_NATIVE_HOST_CC=cc
+
+test-cdk2-qemu: test-cdk2
+	util/testing/cdk2-qemu-test
 
 test-lint:
 	util/lint/lint lint-stable $(JUNIT)
@@ -179,5 +196,5 @@ test-cleanup:
 	$(MAKE) -C src/soc/nvidia/tegra210/lp0 clean
 
 .PHONY: test-basic test-lint test-abuild test-payloads
-.PHONY: test-tools test-cleanup test-help
+.PHONY: test-tools test-cleanup test-help test-cdk2 test-cdk2-qemu
 .PHONY: lint lint-stable what-jenkins-does

--- a/util/testing/cdk2-qemu-test
+++ b/util/testing/cdk2-qemu-test
@@ -22,70 +22,79 @@ command -v timeout >/dev/null
 printf '%s  %s\n' "$CDK2_RETAINED_FV_SHA256" "$CDK2_RETAINED_FV" |
 	sha256sum -c -
 
-top=$(pwd)
-if test -n "${CDK2_QEMU_WORKDIR:-}"; then
-	tmpdir=$CDK2_QEMU_WORKDIR
-	mkdir -p "$tmpdir"
-else
-	tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/coreboot-cdk2-qemu.XXXXXX")
-	trap 'rm -rf "$tmpdir"' EXIT INT TERM
-fi
-config="$tmpdir/.config"
-obj="$tmpdir/build"
-
-cp "${CDK2_QEMU_CONFIG:-configs/config.emulation_qemu_x86_q35_smm_tseg}" "$config"
-{
-	printf '%s\n' 'CONFIG_PAYLOAD_CDK2=y'
-	printf '%s\n' 'CONFIG_USE_X86_64_SUPPORT=y'
-	printf '%s\n' 'CONFIG_CDK2_BUILD_DEBUG=y'
-	printf 'CONFIG_CDK2_RETAINED_FV="%s"\n' "$CDK2_RETAINED_FV"
-	printf 'CONFIG_CDK2_RETAINED_FV_SHA256="%s"\n' "$CDK2_RETAINED_FV_SHA256"
-} >>"$config"
-
-make olddefconfig DOTCONFIG="$config" obj="$obj"
-make -j "${CPUS:-4}" DOTCONFIG="$config" obj="$obj"
 make -C util/smmstoretool
 
-test -s "$obj/coreboot.rom"
-"$obj/cbfstool" "$obj/coreboot.rom" print | grep -q 'fallback/payload'
-
-# Keep the linked image immutable as build evidence.  QEMU receives a
-# deterministically initialized copy because pflash is writable at runtime.
-cp "$obj/coreboot.rom" "$tmpdir/q35.rom"
-util/smmstoretool/smmstoretool "$tmpdir/q35.rom" init
-test -z "$(util/smmstoretool/smmstoretool "$tmpdir/q35.rom" list)"
-
-cp "$CDK2_QEMU_NVME_IMAGE" "$tmpdir/nvme.img"
-cp "$CDK2_QEMU_USB_IMAGE" "$tmpdir/usb.img"
-
-set +e
-timeout "${CDK2_QEMU_TIMEOUT:-80}" qemu-system-x86_64 \
-	-machine q35 -m 512M -nographic -no-reboot \
-	-drive if=pflash,format=raw,file="$tmpdir/q35.rom" \
-	-drive if=none,format=raw,file="$tmpdir/nvme.img",id=nvme \
-	-device nvme,drive=nvme,serial=cdk2 \
-	-drive if=none,format=raw,file="$tmpdir/usb.img",id=usb \
-	-device qemu-xhci -device usb-storage,drive=usb \
-	>"$tmpdir/q35.log" 2>&1
-status=$?
-set -e
-
-if test "$status" -ne 0 && test "$status" -ne 124; then
-	cat "$tmpdir/q35.log" >&2
-	exit "$status"
+top=$(pwd)
+if test -n "${CDK2_QEMU_WORKDIR:-}"; then
+	test_root=$CDK2_QEMU_WORKDIR
+	mkdir -p "$test_root"
+else
+	test_root=$(mktemp -d "${TMPDIR:-/tmp}/coreboot-cdk2-qemu.XXXXXX")
+	trap 'rm -rf "$test_root"' EXIT INT TERM
 fi
 
-for marker in 'UEFI Interactive Shell' 'CDK2_NATIVE_STARTUP' \
-	'CDK2_NATIVE_DONE' 'Reset with <null string>'; do
-	if ! grep -q "$marker" "$tmpdir/q35.log"; then
-		echo "missing CDK2 Q35 marker: $marker" >&2
+for ramstage in ${CDK2_QEMU_RAMSTAGES:-ia32 x86_64}; do
+	case "$ramstage" in
+		ia32|x86_64) ;;
+		*) echo "invalid CDK2 QEMU ramstage: $ramstage" >&2; exit 1 ;;
+	esac
+	tmpdir="$test_root/$ramstage"
+	config="$tmpdir/.config"
+	obj="$tmpdir/build"
+	mkdir -p "$tmpdir"
+	cp "${CDK2_QEMU_CONFIG:-configs/config.emulation_qemu_x86_q35_smm_tseg}" "$config"
+	{
+		printf '%s\n' 'CONFIG_PAYLOAD_CDK2=y'
+		if test "$ramstage" = x86_64; then
+			printf '%s\n' 'CONFIG_USE_X86_64_SUPPORT=y'
+		else
+			printf '%s\n' '# CONFIG_USE_X86_64_SUPPORT is not set'
+		fi
+		printf '%s\n' 'CONFIG_CDK2_BUILD_DEBUG=y'
+		printf 'CONFIG_CDK2_RETAINED_FV="%s"\n' "$CDK2_RETAINED_FV"
+		printf 'CONFIG_CDK2_RETAINED_FV_SHA256="%s"\n' "$CDK2_RETAINED_FV_SHA256"
+	} >>"$config"
+
+	make olddefconfig DOTCONFIG="$config" obj="$obj"
+	make -j "${CPUS:-4}" DOTCONFIG="$config" obj="$obj"
+	test -s "$obj/coreboot.rom"
+	"$obj/cbfstool" "$obj/coreboot.rom" print | grep -q 'fallback/payload'
+
+	# Keep the linked image immutable as build evidence. QEMU receives a
+	# deterministically initialized copy because pflash is writable at runtime.
+	cp "$obj/coreboot.rom" "$tmpdir/q35.rom"
+	util/smmstoretool/smmstoretool "$tmpdir/q35.rom" init
+	test -z "$(util/smmstoretool/smmstoretool "$tmpdir/q35.rom" list)"
+	cp "$CDK2_QEMU_NVME_IMAGE" "$tmpdir/nvme.img"
+	cp "$CDK2_QEMU_USB_IMAGE" "$tmpdir/usb.img"
+
+	set +e
+	timeout "${CDK2_QEMU_TIMEOUT:-80}" qemu-system-x86_64 \
+		-machine q35 -m 512M -nographic -no-reboot \
+		-drive if=pflash,format=raw,file="$tmpdir/q35.rom" \
+		-drive if=none,format=raw,file="$tmpdir/nvme.img",id=nvme \
+		-device nvme,drive=nvme,serial=cdk2 \
+		-drive if=none,format=raw,file="$tmpdir/usb.img",id=usb \
+		-device qemu-xhci -device usb-storage,drive=usb \
+		>"$tmpdir/q35.log" 2>&1
+	status=$?
+	set -e
+
+	if test "$status" -ne 0 && test "$status" -ne 124; then
+		cat "$tmpdir/q35.log" >&2
+		exit "$status"
+	fi
+	for marker in 'UEFI Interactive Shell' 'CDK2_NATIVE_STARTUP' \
+		'CDK2_NATIVE_DONE' 'Reset with <null string>'; do
+		if ! grep -q "$marker" "$tmpdir/q35.log"; then
+			echo "missing CDK2 Q35 $ramstage marker: $marker" >&2
+			cat "$tmpdir/q35.log" >&2
+			exit 1
+		fi
+	done
+	if grep -q 'Exception Type' "$tmpdir/q35.log"; then
 		cat "$tmpdir/q35.log" >&2
 		exit 1
 	fi
+	printf 'CDK2 integrated Q35 %s test: PASS (%s)\n' "$ramstage" "$top"
 done
-if grep -q 'Exception Type' "$tmpdir/q35.log"; then
-	cat "$tmpdir/q35.log" >&2
-	exit 1
-fi
-
-printf 'CDK2 integrated Q35 test: PASS (%s)\n' "$top"

--- a/util/testing/cdk2-qemu-test
+++ b/util/testing/cdk2-qemu-test
@@ -1,0 +1,91 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+
+set -eu
+
+: "${CDK2_RETAINED_FV:?set CDK2_RETAINED_FV to the reviewed transition FV}"
+: "${CDK2_RETAINED_FV_SHA256:?set CDK2_RETAINED_FV_SHA256}"
+: "${CDK2_QEMU_NVME_IMAGE:?set CDK2_QEMU_NVME_IMAGE to the test image}"
+: "${CDK2_QEMU_USB_IMAGE:?set CDK2_QEMU_USB_IMAGE to the startup image}"
+
+for file in "$CDK2_RETAINED_FV" "$CDK2_QEMU_NVME_IMAGE" "$CDK2_QEMU_USB_IMAGE"; do
+	test -f "$file" || {
+		echo "missing CDK2 Q35 input: $file" >&2
+		exit 1
+	}
+done
+
+command -v qemu-system-x86_64 >/dev/null
+command -v sha256sum >/dev/null
+command -v timeout >/dev/null
+
+printf '%s  %s\n' "$CDK2_RETAINED_FV_SHA256" "$CDK2_RETAINED_FV" |
+	sha256sum -c -
+
+top=$(pwd)
+if test -n "${CDK2_QEMU_WORKDIR:-}"; then
+	tmpdir=$CDK2_QEMU_WORKDIR
+	mkdir -p "$tmpdir"
+else
+	tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/coreboot-cdk2-qemu.XXXXXX")
+	trap 'rm -rf "$tmpdir"' EXIT INT TERM
+fi
+config="$tmpdir/.config"
+obj="$tmpdir/build"
+
+cp "${CDK2_QEMU_CONFIG:-configs/config.emulation_qemu_x86_q35_smm_tseg}" "$config"
+{
+	printf '%s\n' 'CONFIG_PAYLOAD_CDK2=y'
+	printf '%s\n' 'CONFIG_USE_X86_64_SUPPORT=y'
+	printf '%s\n' 'CONFIG_CDK2_BUILD_DEBUG=y'
+	printf 'CONFIG_CDK2_RETAINED_FV="%s"\n' "$CDK2_RETAINED_FV"
+	printf 'CONFIG_CDK2_RETAINED_FV_SHA256="%s"\n' "$CDK2_RETAINED_FV_SHA256"
+} >>"$config"
+
+make olddefconfig DOTCONFIG="$config" obj="$obj"
+make -j "${CPUS:-4}" DOTCONFIG="$config" obj="$obj"
+make -C util/smmstoretool
+
+test -s "$obj/coreboot.rom"
+"$obj/cbfstool" "$obj/coreboot.rom" print | grep -q 'fallback/payload'
+
+# Keep the linked image immutable as build evidence.  QEMU receives a
+# deterministically initialized copy because pflash is writable at runtime.
+cp "$obj/coreboot.rom" "$tmpdir/q35.rom"
+util/smmstoretool/smmstoretool "$tmpdir/q35.rom" init
+test -z "$(util/smmstoretool/smmstoretool "$tmpdir/q35.rom" list)"
+
+cp "$CDK2_QEMU_NVME_IMAGE" "$tmpdir/nvme.img"
+cp "$CDK2_QEMU_USB_IMAGE" "$tmpdir/usb.img"
+
+set +e
+timeout "${CDK2_QEMU_TIMEOUT:-80}" qemu-system-x86_64 \
+	-machine q35 -m 512M -nographic -no-reboot \
+	-drive if=pflash,format=raw,file="$tmpdir/q35.rom" \
+	-drive if=none,format=raw,file="$tmpdir/nvme.img",id=nvme \
+	-device nvme,drive=nvme,serial=cdk2 \
+	-drive if=none,format=raw,file="$tmpdir/usb.img",id=usb \
+	-device qemu-xhci -device usb-storage,drive=usb \
+	>"$tmpdir/q35.log" 2>&1
+status=$?
+set -e
+
+if test "$status" -ne 0 && test "$status" -ne 124; then
+	cat "$tmpdir/q35.log" >&2
+	exit "$status"
+fi
+
+for marker in 'UEFI Interactive Shell' 'CDK2_NATIVE_STARTUP' \
+	'CDK2_NATIVE_DONE' 'Reset with <null string>'; do
+	if ! grep -q "$marker" "$tmpdir/q35.log"; then
+		echo "missing CDK2 Q35 marker: $marker" >&2
+		cat "$tmpdir/q35.log" >&2
+		exit 1
+	fi
+done
+if grep -q 'Exception Type' "$tmpdir/q35.log"; then
+	cat "$tmpdir/q35.log" >&2
+	exit 1
+fi
+
+printf 'CDK2 integrated Q35 test: PASS (%s)\n' "$top"


### PR DESCRIPTION
## Summary

- add CDK2 at readiness head `a10b336543093ea32b911bce258b931675fb8020` as a source submodule and invoke its owned build/tests explicitly
- add a fail-closed transitional retained-FV input with digest and inventory validation
- add an integrated Q35 build/boot oracle using coreboot tables, pinned cross-toolchain builds, and writable pflash
- add deterministic, idempotent `smmstoretool init` support for an empty first-boot variable store

## Validation

- `make lint-stable`
- `make test-cdk2 CPUS=4 CDK2_NATIVE_CC=cc CDK2_NATIVE_HOST_CC=cc`
- `make -C util/smmstoretool test`
- pinned coreboot toolchain v2026-07-16_7549c0f6f8 (GCC 15.2.0), IASL 20251212
- integrated Q35: UEFI shell, `CDK2_NATIVE_STARTUP`, `CDK2_NATIVE_DONE`, clean reset; no exception
