### PR TITLE
payloads/cdk2: publish the SMRAM handoff

### DIFF
--- a/src/commonlib/include/commonlib/coreboot_tables.h
+++ b/src/commonlib/include/commonlib/coreboot_tables.h
@@ -93,6 +93,7 @@ enum {
 	LB_TAG_ROOT_BRIDGE_INFO		= 0x0048,
 	LB_TAG_PANEL_POWEROFF		= 0x0049,
 	LB_TAG_SDHCI_NONPCI		= 0x004a,
+	LB_TAG_SMRAM			= 0x004c,
 	/* The following options are CMOS-related */
 	LB_TAG_CMOS_OPTION_TABLE	= 0x00c8,
 	LB_TAG_OPTION			= 0x00c9,
@@ -159,6 +160,13 @@ struct lb_memory {
 	uint32_t tag;
 	uint32_t size;
 	struct lb_memory_range map[];
+};
+
+struct lb_smram {
+	uint32_t tag;
+	uint32_t size;
+	lb_uint64_t physical_start;
+	lb_uint64_t physical_size;
 };
 
 struct lb_pcie {

--- a/src/lib/coreboot_table.c
+++ b/src/lib/coreboot_table.c
@@ -20,6 +20,9 @@
 #include <fw_config.h>
 #include <cbfs.h>
 #include <cbmem.h>
+#if CONFIG(ARCH_X86)
+#include <cpu/x86/smm.h>
+#endif
 #include <bootmem.h>
 #include <bootsplash.h>
 #include <inttypes.h>
@@ -157,6 +160,29 @@ static void lb_framebuffer(struct lb_header *header)
 		unsigned int depth = framebuffer->bits_per_pixel;
 		set_bootsplash(fb_ptr, width, height, bytes_per_line, depth);
 	}
+}
+
+static void lb_smram(struct lb_header *header)
+{
+	(void)header;
+#if CONFIG(ARCH_X86)
+	struct lb_smram *smram;
+	uintptr_t base;
+	size_t size;
+
+	if (!CONFIG(HAVE_SMI_HANDLER))
+		return;
+
+	smm_region(&base, &size);
+	if (size == 0)
+		return;
+
+	smram = (struct lb_smram *)lb_new_record(header);
+	smram->tag = LB_TAG_SMRAM;
+	smram->size = sizeof(*smram);
+	smram->physical_start = base;
+	smram->physical_size = size;
+#endif
 }
 
 void lb_add_gpios(struct lb_gpios *gpios, const struct lb_gpio *gpio_table,
@@ -607,6 +633,9 @@ uintptr_t write_coreboot_table(uintptr_t rom_table_end)
 	/* SMMSTORE */
 	if (CONFIG(SMMSTORE))
 		lb_smmstorev2(head);
+
+	/* SMRAM range for payload SMM protocol initialization. */
+	lb_smram(head);
 
 	/* Non-PCI SDHCI controller list for payloads */
 	lb_sdhci_nonpci(head);


### PR DESCRIPTION
## Summary
- add a bounded coreboot-table SMRAM record populated from the platform SMM region
- make the record available to CDK2 without hardcoding QEMU TSEG addresses
- pin CDK2 PR #150, which translates the record into the PI SMRAM memory GUID HOB

## Validation
- `make lint-stable`
- explicit CDK2 `what-jenkins-does` and native/inventory gates
- exact integrated Q35 carrier in both IA32 and x86_64 modes: UEFI shell, startup/done markers and reset

Paired with StarLabsLtd/cdk2#150.