### PR TITLE
payloads/cdk2: publish the SMI control registers

### DIFF
--- a/src/commonlib/include/commonlib/coreboot_tables.h
+++ b/src/commonlib/include/commonlib/coreboot_tables.h
@@ -94,6 +94,7 @@ enum {
 	LB_TAG_PANEL_POWEROFF		= 0x0049,
 	LB_TAG_SDHCI_NONPCI		= 0x004a,
 	LB_TAG_SMRAM			= 0x004c,
+	LB_TAG_SMM_REGISTER_INFO	= 0x004d,
 	/* The following options are CMOS-related */
 	LB_TAG_CMOS_OPTION_TABLE	= 0x00c8,
 	LB_TAG_OPTION			= 0x00c9,
@@ -168,6 +169,25 @@ struct lb_smram {
 	lb_uint64_t physical_start;
 	lb_uint64_t physical_size;
 };
+
+struct lb_smm_generic_register {
+	lb_uint64_t id;
+	lb_uint64_t value;
+	uint8_t address_space_id;
+	uint8_t register_bit_width;
+	uint8_t register_bit_offset;
+	uint8_t access_size;
+	lb_uint64_t address;
+} __packed;
+
+struct lb_smm_register_info {
+	uint32_t tag;
+	uint32_t size;
+	uint16_t revision;
+	uint16_t reserved;
+	uint32_t count;
+	struct lb_smm_generic_register registers[4];
+} __packed;
 
 struct lb_pcie {
 	uint32_t tag;

--- a/src/lib/coreboot_table.c
+++ b/src/lib/coreboot_table.c
@@ -23,6 +23,10 @@
 #if CONFIG(ARCH_X86)
 #include <cpu/x86/smm.h>
 #endif
+#if CONFIG(SOUTHBRIDGE_INTEL_COMMON_PMBASE)
+#include <southbridge/intel/common/pmbase.h>
+#include <southbridge/intel/common/pmutil.h>
+#endif
 #include <bootmem.h>
 #include <bootsplash.h>
 #include <inttypes.h>
@@ -182,6 +186,68 @@ static void lb_smram(struct lb_header *header)
 	smram->size = sizeof(*smram);
 	smram->physical_start = base;
 	smram->physical_size = size;
+#endif
+}
+
+static void lb_smm_register_info(struct lb_header *header)
+{
+	(void)header;
+#if CONFIG(SOUTHBRIDGE_INTEL_COMMON_PMBASE)
+	struct lb_smm_register_info *info;
+	uint16_t smi_en;
+
+	if (!CONFIG(HAVE_SMI_HANDLER))
+		return;
+
+	smi_en = lpc_get_pmbase() + SMI_EN;
+	if (smi_en == SMI_EN)
+		return;
+
+	info = (struct lb_smm_register_info *)lb_new_record(header);
+	*info = (struct lb_smm_register_info){
+		.tag = LB_TAG_SMM_REGISTER_INFO,
+		.size = sizeof(*info),
+		.revision = 1,
+		.count = 4,
+		.registers = {
+			{
+				.id = 1,
+				.value = 1,
+				.address_space_id = 1,
+				.register_bit_width = 1,
+				.register_bit_offset = 0,
+				.access_size = 3,
+				.address = smi_en,
+			},
+			{
+				.id = 3,
+				.value = 1,
+				.address_space_id = 1,
+				.register_bit_width = 1,
+				.register_bit_offset = 1,
+				.access_size = 3,
+				.address = smi_en,
+			},
+			{
+				.id = 4,
+				.value = 1,
+				.address_space_id = 1,
+				.register_bit_width = 1,
+				.register_bit_offset = 5,
+				.access_size = 3,
+				.address = smi_en,
+			},
+			{
+				.id = 5,
+				.value = 1,
+				.address_space_id = 1,
+				.register_bit_width = 1,
+				.register_bit_offset = 5,
+				.access_size = 3,
+				.address = smi_en + (SMI_STS - SMI_EN),
+			},
+		},
+	};
 #endif
 }
 
@@ -636,6 +702,7 @@ uintptr_t write_coreboot_table(uintptr_t rom_table_end)
 
 	/* SMRAM range for payload SMM protocol initialization. */
 	lb_smram(head);
+	lb_smm_register_info(head);
 
 	/* Non-PCI SDHCI controller list for payloads */
 	lb_sdhci_nonpci(head);


### PR DESCRIPTION
## Summary
- publish the Intel common PMBASE SMI enable register as an explicit coreboot-table contract
- describe global-SMI and APM enable bits using the PI generic-register representation
- pin CDK2 PR #151, which validates the record and publishes SMM Control2

## Validation
- coreboot stable lint and explicit CDK2 CI
- exact integrated Q35 in both IA32 and x86_64 modes: UEFI shell, startup/done markers and reset

Paired with StarLabsLtd/cdk2#151.