### PR TITLE
payloads: add pinned external CDK2 integration

### DIFF
--- a/payloads/external/Makefile.mk
+++ b/payloads/external/Makefile.mk
@@ -8,16 +8,19 @@ CDK2_SOURCE_DIR := $(if $(filter /%,$(CDK2_SOURCE_PATH)),$(CDK2_SOURCE_PATH),$(C
 CDK2_PROFILE_CONFIG := $(obj)/cdk2-profile.config
 CDK2_PAYLOAD := $(obj)/cdk2/native/cdk2-coreboot-stage.elf
 
+.PHONY: cdk2-source-state
+cdk2-source-state:
+
 $(CDK2_PROFILE_CONFIG): util/cdk2-config $(DOTCONFIG)
 	@printf '    CDK2       %s\n' "$@"
 	@util/cdk2-config "$@"
 
-$(CDK2_PAYLOAD): $(DOTCONFIG) $(CDK2_PROFILE_CONFIG) util/cdk2-build
+$(CDK2_PAYLOAD): $(DOTCONFIG) $(CDK2_PROFILE_CONFIG) util/cdk2-build cdk2-source-state
 	@printf '    CDK2       %s\n' "$@"
 	@util/cdk2-build "$(CDK2_SOURCE_DIR)" \
 		"$(call strip_quotes,$(CONFIG_CDK2_SOURCE_REVISION))" \
 		"$(abspath $(DOTCONFIG))" "$(abspath $(CDK2_PROFILE_CONFIG))" \
-		"$(abspath $(obj)/cdk2)"
+		"$(abspath $(obj)/cdk2)" "$(MAKE)"
 
 endif
 

--- a/payloads/external/Makefile.mk
+++ b/payloads/external/Makefile.mk
@@ -1,5 +1,26 @@
 ## SPDX-License-Identifier: GPL-2.0-only
 
+# CDK2
+
+ifeq ($(CONFIG_PAYLOAD_CDK2),y)
+CDK2_SOURCE_PATH := $(call strip_quotes,$(CONFIG_CDK2_SOURCE_PATH))
+CDK2_SOURCE_DIR := $(if $(filter /%,$(CDK2_SOURCE_PATH)),$(CDK2_SOURCE_PATH),$(CURDIR)/$(CDK2_SOURCE_PATH))
+CDK2_PROFILE_CONFIG := $(obj)/cdk2-profile.config
+CDK2_PAYLOAD := $(obj)/cdk2/native/cdk2-coreboot-stage.elf
+
+$(CDK2_PROFILE_CONFIG): util/cdk2-config $(DOTCONFIG)
+	@printf '    CDK2       %s\n' "$@"
+	@util/cdk2-config "$@"
+
+$(CDK2_PAYLOAD): $(DOTCONFIG) $(CDK2_PROFILE_CONFIG) util/cdk2-build
+	@printf '    CDK2       %s\n' "$@"
+	@util/cdk2-build "$(CDK2_SOURCE_DIR)" \
+		"$(call strip_quotes,$(CONFIG_CDK2_SOURCE_REVISION))" \
+		"$(abspath $(DOTCONFIG))" "$(abspath $(CDK2_PROFILE_CONFIG))" \
+		"$(abspath $(obj)/cdk2)"
+
+endif
+
 # set up payload config and version files for later inclusion
 ifeq ($(CONFIG_PAYLOAD_BUILD_SEABIOS),y)
 PAYLOAD_CONFIG=payloads/external/SeaBIOS/seabios/.config

--- a/payloads/external/cdk2/Kconfig
+++ b/payloads/external/cdk2/Kconfig
@@ -1,0 +1,22 @@
+## SPDX-License-Identifier: GPL-2.0-only
+
+if PAYLOAD_CDK2
+
+config CDK2_SOURCE_PATH
+	string "Path to the CDK2 source checkout"
+	default "../cdk2"
+	help
+	  Path relative to the coreboot source root, or an absolute path.  The
+	  checkout is never modified and all build output is kept under obj/.
+
+config CDK2_SOURCE_REVISION
+	string "Required CDK2 source revision"
+	default "b6c70863f4d0c8b893d561397fab8c4abb61d382"
+	help
+	  Full commit object name required at the source checkout's HEAD.  Builds
+	  fail when this is empty, differs from HEAD, or the checkout is dirty.
+
+config PAYLOAD_FILE
+	default "$(obj)/cdk2/native/cdk2-coreboot-stage.elf"
+
+endif

--- a/payloads/external/cdk2/Kconfig.name
+++ b/payloads/external/cdk2/Kconfig.name
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: GPL-2.0-only
+
+config PAYLOAD_CDK2
+	bool "CDK2 payload"
+	depends on ARCH_X86
+	depends on BOOT_DEVICE_SUPPORTS_WRITES && HAVE_SMI_HANDLER
+	select HANDOFF_COREBOOT_TABLES
+	select PAYLOAD_OWNS_PCI_DEVICES
+	select WANT_LINEAR_FRAMEBUFFER
+	select SMMSTORE
+	help
+	  Build the CDK2 payload from a pinned, clean source checkout.  Platform
+	  policy is translated into one generated CDK2 configuration fragment;
+	  payload-internal Kconfig choices are not exposed in coreboot.

--- a/tests/cdk2-external-test.sh
+++ b/tests/cdk2-external-test.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+source_dir="$tmp/source"
+mkdir -p "$source_dir"
+git -C "$source_dir" init -q
+git -C "$source_dir" config user.email test@example.com
+git -C "$source_dir" config user.name Test
+cat > "$source_dir/Makefile" <<'EOF'
+coreboot-stage:
+	@test -n "$(COREBOOT_CONFIG)"
+	@test -n "$(COREBOOT_CDK2_PROFILE)"
+	@test -n "$(COREBOOT_OUTPUT_DIR)"
+	@mkdir -p "$(COREBOOT_OUTPUT_DIR)/native"
+	@cp "$(COREBOOT_CDK2_PROFILE)" "$(COREBOOT_OUTPUT_DIR)/received.config"
+	@touch "$(COREBOOT_OUTPUT_DIR)/native/cdk2-coreboot-stage.elf"
+EOF
+git -C "$source_dir" add Makefile
+git -C "$source_dir" commit -q -m fixture
+revision=$(git -C "$source_dir" rev-parse HEAD)
+echo 'CONFIG_PAYLOAD_CDK2=y' > "$tmp/coreboot.config"
+"$root/util/cdk2-config" "$tmp/profile"
+"$root/util/cdk2-build" "$source_dir" "$revision" \
+	"$tmp/coreboot.config" "$tmp/profile" "$tmp/output"
+cmp "$tmp/profile" "$tmp/output/received.config"
+test -f "$tmp/output/native/cdk2-coreboot-stage.elf"
+
+if "$root/util/cdk2-build" "$source_dir" \
+	0000000000000000000000000000000000000000 "$tmp/coreboot.config" \
+	"$tmp/profile" "$tmp/bad-revision" 2> "$tmp/error"; then
+	echo 'mismatched CDK2 revision unexpectedly accepted' >&2
+	exit 1
+fi
+grep -q 'revision mismatch' "$tmp/error"
+
+echo changed >> "$source_dir/Makefile"
+if "$root/util/cdk2-build" "$source_dir" "$revision" \
+	"$tmp/coreboot.config" "$tmp/profile" "$tmp/dirty" 2> "$tmp/error"; then
+	echo 'dirty CDK2 checkout unexpectedly accepted' >&2
+	exit 1
+fi
+grep -q 'tracked modifications' "$tmp/error"
+
+for board in config.emulation_qemu_x86_q35_smm_tseg config.starlabs_starbook_mtl; do
+	cp "$root/configs/$board" "$tmp/$board"
+	echo 'CONFIG_PAYLOAD_CDK2=y' >> "$tmp/$board"
+	make -s -C "$root" DOTCONFIG="$tmp/$board" olddefconfig
+	for symbol in PAYLOAD_CDK2 HANDOFF_COREBOOT_TABLES \
+		PAYLOAD_OWNS_PCI_DEVICES WANT_LINEAR_FRAMEBUFFER SMMSTORE; do
+		grep -qx "CONFIG_${symbol}=y" "$tmp/$board"
+	done
+	grep -qx 'CONFIG_CDK2_SOURCE_REVISION="b6c70863f4d0c8b893d561397fab8c4abb61d382"' \
+		"$tmp/$board"
+done
+
+# Merely adding CDK2 must not perturb the existing EDK2 selection.
+cp "$root/configs/config.starlabs_starbook_mtl" "$tmp/edk2"
+make -s -C "$root" DOTCONFIG="$tmp/edk2" olddefconfig
+grep -qx 'CONFIG_PAYLOAD_EDK2=y' "$tmp/edk2"
+grep -qx '# CONFIG_PAYLOAD_CDK2 is not set' "$tmp/edk2"

--- a/tests/cdk2-external-test.sh
+++ b/tests/cdk2-external-test.sh
@@ -3,6 +3,7 @@
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+make_command=${MAKE:-make}
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 source_dir="$tmp/source"
@@ -62,7 +63,8 @@ grep -q 'tracked modifications' "$tmp/error"
 for board in config.emulation_qemu_x86_q35_smm_tseg config.starlabs_starbook_mtl; do
 	cp "$root/configs/$board" "$tmp/$board"
 	echo 'CONFIG_PAYLOAD_CDK2=y' >> "$tmp/$board"
-	make -s -C "$root" DOTCONFIG="$tmp/$board" olddefconfig
+	"$make_command" -s -C "$root" DOTCONFIG="$tmp/$board" \
+		obj="$tmp/build-$board" olddefconfig
 	for symbol in PAYLOAD_CDK2 HANDOFF_COREBOOT_TABLES \
 		PAYLOAD_OWNS_PCI_DEVICES WANT_LINEAR_FRAMEBUFFER SMMSTORE; do
 		grep -qx "CONFIG_${symbol}=y" "$tmp/$board"
@@ -73,6 +75,7 @@ done
 
 # Merely adding CDK2 must not perturb the existing EDK2 selection.
 cp "$root/configs/config.starlabs_starbook_mtl" "$tmp/edk2"
-make -s -C "$root" DOTCONFIG="$tmp/edk2" olddefconfig
+"$make_command" -s -C "$root" DOTCONFIG="$tmp/edk2" \
+	obj="$tmp/build-edk2" olddefconfig
 grep -qx 'CONFIG_PAYLOAD_EDK2=y' "$tmp/edk2"
 grep -qx '# CONFIG_PAYLOAD_CDK2 is not set' "$tmp/edk2"

--- a/tests/cdk2-external-test.sh
+++ b/tests/cdk2-external-test.sh
@@ -8,7 +8,7 @@ tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 source_dir="$tmp/source"
 mkdir -p "$source_dir"
-git -C "$source_dir" init -q
+git -C "$source_dir" init -q --object-format=sha1
 git -C "$source_dir" config user.email test@example.com
 git -C "$source_dir" config user.name Test
 cat > "$source_dir/Makefile" <<'EOF'
@@ -28,12 +28,12 @@ coreboot-stage:
 	@touch "$(COREBOOT_OUTPUT_DIR)/native/cdk2-coreboot-stage.elf"
 EOF
 git -C "$source_dir" add Makefile
-git -C "$source_dir" commit -q -m fixture
+git -C "$source_dir" -c commit.gpgSign=false commit -q -m fixture
 revision=$(git -C "$source_dir" rev-parse HEAD)
 cat > "$tmp/gmake" <<EOF
 #!/bin/sh
 echo invoked > "$tmp/make-invoked"
-exec make "\$@"
+exec "$make_command" "\$@"
 EOF
 chmod +x "$tmp/gmake"
 echo 'CONFIG_PAYLOAD_CDK2=y' > "$tmp/coreboot.config"

--- a/tests/cdk2-external-test.sh
+++ b/tests/cdk2-external-test.sh
@@ -20,6 +20,9 @@ coreboot-stage:
 	@test -z "$(obj)"
 	@test -z "$(top)"
 	@test -z "$(src)"
+	@test "$(origin AR)$(origin AS)$(origin LD)" = defaultdefaultdefault
+	@test "$(origin NM)$(origin OBJCOPY)$(origin OBJDUMP)" = undefinedundefinedundefined
+	@test "$(origin RANLIB)$(origin STRIP)" = undefinedundefined
 	@mkdir -p "$(COREBOOT_OUTPUT_DIR)/native"
 	@cp "$(COREBOOT_CDK2_PROFILE)" "$(COREBOOT_OUTPUT_DIR)/received.config"
 	@touch "$(COREBOOT_OUTPUT_DIR)/native/cdk2-coreboot-stage.elf"
@@ -37,6 +40,8 @@ echo 'CONFIG_PAYLOAD_CDK2=y' > "$tmp/coreboot.config"
 "$root/util/cdk2-config" "$tmp/profile"
 COREBOOT_EXPORTS='COREBOOT_EXPORTS KCONFIG_CONFIG obj top src' \
 	KCONFIG_CONFIG=wrong obj=wrong top=wrong src=wrong \
+	AR=wrong AS=wrong LD=wrong NM=wrong OBJCOPY=wrong OBJDUMP=wrong \
+	RANLIB=wrong STRIP=wrong \
 	"$root/util/cdk2-build" "$source_dir" "$revision" \
 	"$tmp/coreboot.config" "$tmp/profile" "$tmp/output" \
 	"$tmp/gmake"

--- a/tests/cdk2-external-test.sh
+++ b/tests/cdk2-external-test.sh
@@ -15,6 +15,10 @@ coreboot-stage:
 	@test -n "$(COREBOOT_CONFIG)"
 	@test -n "$(COREBOOT_CDK2_PROFILE)"
 	@test -n "$(COREBOOT_OUTPUT_DIR)"
+	@test -z "$(KCONFIG_CONFIG)"
+	@test -z "$(obj)"
+	@test -z "$(top)"
+	@test -z "$(src)"
 	@mkdir -p "$(COREBOOT_OUTPUT_DIR)/native"
 	@cp "$(COREBOOT_CDK2_PROFILE)" "$(COREBOOT_OUTPUT_DIR)/received.config"
 	@touch "$(COREBOOT_OUTPUT_DIR)/native/cdk2-coreboot-stage.elf"
@@ -22,10 +26,20 @@ EOF
 git -C "$source_dir" add Makefile
 git -C "$source_dir" commit -q -m fixture
 revision=$(git -C "$source_dir" rev-parse HEAD)
+cat > "$tmp/gmake" <<EOF
+#!/bin/sh
+echo invoked > "$tmp/make-invoked"
+exec make "\$@"
+EOF
+chmod +x "$tmp/gmake"
 echo 'CONFIG_PAYLOAD_CDK2=y' > "$tmp/coreboot.config"
 "$root/util/cdk2-config" "$tmp/profile"
-"$root/util/cdk2-build" "$source_dir" "$revision" \
-	"$tmp/coreboot.config" "$tmp/profile" "$tmp/output"
+COREBOOT_EXPORTS='COREBOOT_EXPORTS KCONFIG_CONFIG obj top src' \
+	KCONFIG_CONFIG=wrong obj=wrong top=wrong src=wrong \
+	"$root/util/cdk2-build" "$source_dir" "$revision" \
+	"$tmp/coreboot.config" "$tmp/profile" "$tmp/output" \
+	"$tmp/gmake"
+test -f "$tmp/make-invoked"
 cmp "$tmp/profile" "$tmp/output/received.config"
 test -f "$tmp/output/native/cdk2-coreboot-stage.elf"
 

--- a/util/cdk2-build
+++ b/util/cdk2-build
@@ -1,0 +1,58 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+source_dir=${1:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
+revision=${2:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
+coreboot_config=${3:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
+profile=${4:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
+output_dir=${5:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
+
+case "$revision" in
+	*[!0-9a-f]* )
+		echo 'CDK2_SOURCE_REVISION must be a full hexadecimal commit object name' >&2
+		exit 1
+		;;
+esac
+[ "${#revision}" -eq 40 ] || {
+	echo 'CDK2_SOURCE_REVISION must contain exactly 40 hexadecimal digits' >&2
+	exit 1
+}
+[ -f "$source_dir/Makefile" ] || {
+	echo "CDK2 source Makefile does not exist: $source_dir/Makefile" >&2
+	exit 1
+}
+head=$(git -C "$source_dir" rev-parse --verify HEAD^{commit})
+[ "$head" = "$revision" ] || {
+	echo "CDK2 source revision mismatch: expected $revision, found $head" >&2
+	exit 1
+}
+git -C "$source_dir" diff-index --quiet HEAD -- || {
+	echo "CDK2 source checkout has tracked modifications: $source_dir" >&2
+	exit 1
+}
+test -z "$(git -C "$source_dir" status --porcelain --untracked-files=all)" || {
+	echo "CDK2 source checkout is not clean: $source_dir" >&2
+	exit 1
+}
+[ -f "$coreboot_config" ] || {
+	echo "coreboot configuration does not exist: $coreboot_config" >&2
+	exit 1
+}
+[ -s "$profile" ] || {
+	echo "CDK2 profile is missing or empty: $profile" >&2
+	exit 1
+}
+
+mkdir -p "$output_dir"
+# coreboot exports stage-specific compiler command lines.  They are not valid
+# CDK2 host/native tool selections and must not leak across the payload build
+# boundary; CDK2 chooses its own deterministic defaults (or explicit caller
+# overrides in its standalone build).
+exec env -u CC -u HOSTCC -u CFLAGS -u CPPFLAGS -u LDFLAGS \
+	-u OBJCOPY -u NM -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES \
+	make -C "$source_dir" \
+	COREBOOT_CONFIG="$coreboot_config" \
+	COREBOOT_CDK2_PROFILE="$profile" \
+	COREBOOT_OUTPUT_DIR="$output_dir" \
+	coreboot-stage

--- a/util/cdk2-build
+++ b/util/cdk2-build
@@ -6,7 +6,8 @@ source_dir=${1:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT
 revision=${2:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
 coreboot_config=${3:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
 profile=${4:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
-output_dir=${5:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
+output_dir=${5:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR MAKE}
+make_command=${6:-make}
 
 case "$revision" in
 	*[!0-9a-f]* )
@@ -49,9 +50,10 @@ mkdir -p "$output_dir"
 # CDK2 host/native tool selections and must not leak across the payload build
 # boundary; CDK2 chooses its own deterministic defaults (or explicit caller
 # overrides in its standalone build).
+unset ${COREBOOT_EXPORTS:-}
 exec env -u CC -u HOSTCC -u CFLAGS -u CPPFLAGS -u LDFLAGS \
 	-u OBJCOPY -u NM -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES \
-	make -C "$source_dir" \
+	"$make_command" -C "$source_dir" \
 	COREBOOT_CONFIG="$coreboot_config" \
 	COREBOOT_CDK2_PROFILE="$profile" \
 	COREBOOT_OUTPUT_DIR="$output_dir" \

--- a/util/cdk2-build
+++ b/util/cdk2-build
@@ -52,7 +52,8 @@ mkdir -p "$output_dir"
 # overrides in its standalone build).
 unset ${COREBOOT_EXPORTS:-}
 exec env -u CC -u HOSTCC -u CFLAGS -u CPPFLAGS -u LDFLAGS \
-	-u OBJCOPY -u NM -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES \
+	-u AR -u AS -u LD -u NM -u OBJCOPY -u OBJDUMP -u RANLIB -u STRIP \
+	-u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES \
 	"$make_command" -C "$source_dir" \
 	COREBOOT_CONFIG="$coreboot_config" \
 	COREBOOT_CDK2_PROFILE="$profile" \

--- a/util/cdk2-config
+++ b/util/cdk2-config
@@ -1,0 +1,9 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+output=${1:?usage: cdk2-config OUTPUT}
+tmp="${output}.tmp"
+
+echo 'CONFIG_CDK2_PAYLOAD=y' > "$tmp"
+mv "$tmp" "$output"

--- a/util/testing/Makefile.mk
+++ b/util/testing/Makefile.mk
@@ -150,6 +150,7 @@ test-payloads:
 		|| exit 1; )
 
 test-tools:
+	tests/cdk2-external-test.sh
 	@echo "Build testing $(TOOLLIST)"
 	$(foreach tool, $(TOOLLIST),  echo "Building $(tool)";$(MAKE) CPUS=$(CPUS) V=$(V) Q=$(Q) BLD_DIR="util/$(tool)" BLD="$(tool)" MFLAGS= MAKEFLAGS= MAKETARGET= junit.xml; )
 	unset COREBOOT_BUILD_DIR;$(MAKE) CPUS=$(CPUS) V=$(V) Q=$(Q) BLD_DIR=payloads/nvramcui BLD=nvramcui MFLAGS= MAKEFLAGS= MAKETARGET=all junit.xml

--- a/util/testing/Makefile.mk
+++ b/util/testing/Makefile.mk
@@ -150,7 +150,7 @@ test-payloads:
 		|| exit 1; )
 
 test-tools:
-	tests/cdk2-external-test.sh
+	MAKE='$(MAKE)' tests/cdk2-external-test.sh
 	@echo "Build testing $(TOOLLIST)"
 	$(foreach tool, $(TOOLLIST),  echo "Building $(tool)";$(MAKE) CPUS=$(CPUS) V=$(V) Q=$(Q) BLD_DIR="util/$(tool)" BLD="$(tool)" MFLAGS= MAKEFLAGS= MAKETARGET= junit.xml; )
 	unset COREBOOT_BUILD_DIR;$(MAKE) CPUS=$(CPUS) V=$(V) Q=$(Q) BLD_DIR=payloads/nvramcui BLD=nvramcui MFLAGS= MAKEFLAGS= MAKETARGET=all junit.xml


### PR DESCRIPTION
Add CDK2 as a pinned external payload with all build output kept under coreboot obj/. Generate one deterministic profile fragment from the resolved coreboot configuration, reject dirty or mismatched source revisions, and clear coreboot stage compiler overrides at the payload boundary. Existing EDK2 selection remains unchanged.

The focused integration test covers revision, dirtiness, hostile compiler environment, profile handoff, Q35 and StarBook configuration, and missing-input failures.