### PR TITLE
payloads: compose CDK2 with an admitted retained FV

### DIFF
--- a/payloads/external/Makefile.mk
+++ b/payloads/external/Makefile.mk
@@ -5,8 +5,10 @@
 ifeq ($(CONFIG_PAYLOAD_CDK2),y)
 CDK2_SOURCE_PATH := $(call strip_quotes,$(CONFIG_CDK2_SOURCE_PATH))
 CDK2_SOURCE_DIR := $(if $(filter /%,$(CDK2_SOURCE_PATH)),$(CDK2_SOURCE_PATH),$(CURDIR)/$(CDK2_SOURCE_PATH))
+CDK2_RETAINED_FV_PATH := $(call strip_quotes,$(CONFIG_CDK2_RETAINED_FV_PATH))
+CDK2_RETAINED_FV := $(if $(filter /%,$(CDK2_RETAINED_FV_PATH)),$(CDK2_RETAINED_FV_PATH),$(CURDIR)/$(CDK2_RETAINED_FV_PATH))
 CDK2_PROFILE_CONFIG := $(obj)/cdk2-profile.config
-CDK2_PAYLOAD := $(obj)/cdk2/native/cdk2-coreboot-stage.elf
+CDK2_PAYLOAD := $(obj)/cdk2/native/cdk2-coreboot-image.elf
 
 .PHONY: cdk2-source-state
 cdk2-source-state:
@@ -20,7 +22,9 @@ $(CDK2_PAYLOAD): $(DOTCONFIG) $(CDK2_PROFILE_CONFIG) util/cdk2-build cdk2-source
 	@util/cdk2-build "$(CDK2_SOURCE_DIR)" \
 		"$(call strip_quotes,$(CONFIG_CDK2_SOURCE_REVISION))" \
 		"$(abspath $(DOTCONFIG))" "$(abspath $(CDK2_PROFILE_CONFIG))" \
-		"$(abspath $(obj)/cdk2)" "$(MAKE)"
+		"$(abspath $(obj)/cdk2)" "$(abspath $(CDK2_RETAINED_FV))" \
+		"$(call strip_quotes,$(CONFIG_CDK2_RETAINED_FV_SHA256))" \
+		"$(MAKE)"
 
 endif
 

--- a/payloads/external/cdk2/Kconfig
+++ b/payloads/external/cdk2/Kconfig
@@ -11,12 +11,25 @@ config CDK2_SOURCE_PATH
 
 config CDK2_SOURCE_REVISION
 	string "Required CDK2 source revision"
-	default "b6c70863f4d0c8b893d561397fab8c4abb61d382"
+	default "8bbabbd2557057f1b5112229a8b189fa99289d7c"
 	help
 	  Full commit object name required at the source checkout's HEAD.  Builds
 	  fail when this is empty, differs from HEAD, or the checkout is dirty.
 
+config CDK2_RETAINED_FV_PATH
+	string "Path to the admitted retained DXE firmware volume"
+	help
+	  Path to the retained EDK2 firmware volume used to compose the complete
+	  CDK2 payload image.  A stage-only payload cannot dispatch DXE drivers.
+
+config CDK2_RETAINED_FV_SHA256
+	string
+	default "ca1ebfd0ff6c7c82935a4302c1ddc4cc418ed177756c678260dfb09527e1f50e"
+	help
+	  Pinned digest of the admitted retained firmware volume.  This prevents
+	  an unreviewed FV from silently changing the paired payload composition.
+
 config PAYLOAD_FILE
-	default "$(obj)/cdk2/native/cdk2-coreboot-stage.elf"
+	default "$(obj)/cdk2/native/cdk2-coreboot-image.elf"
 
 endif

--- a/tests/cdk2-external-test.sh
+++ b/tests/cdk2-external-test.sh
@@ -33,7 +33,13 @@ git -C "$source_dir" -c commit.gpgSign=false commit -q -m fixture
 revision=$(git -C "$source_dir" rev-parse HEAD)
 echo 'CONFIG_PAYLOAD_CDK2=y' > "$tmp/coreboot.config"
 printf 'admitted retained FV fixture\n' > "$tmp/retained.fv"
-retained_hash=$(sha256sum "$tmp/retained.fv" | awk '{print $1}')
+if command -v sha256sum >/dev/null 2>&1; then
+	retained_hash=$(sha256sum "$tmp/retained.fv" | awk '{print $1}')
+elif command -v sha256 >/dev/null 2>&1; then
+	retained_hash=$(sha256 -q "$tmp/retained.fv")
+else
+	retained_hash=$(shasum -a 256 "$tmp/retained.fv" | awk '{print $1}')
+fi
 cat > "$tmp/gmake" <<EOF
 #!/bin/sh
 echo invoked > "$tmp/make-invoked"

--- a/tests/cdk2-external-test.sh
+++ b/tests/cdk2-external-test.sh
@@ -12,10 +12,11 @@ git -C "$source_dir" init -q --object-format=sha1
 git -C "$source_dir" config user.email test@example.com
 git -C "$source_dir" config user.name Test
 cat > "$source_dir/Makefile" <<'EOF'
-coreboot-stage:
+native-coreboot-image:
 	@test -n "$(COREBOOT_CONFIG)"
 	@test -n "$(COREBOOT_CDK2_PROFILE)"
-	@test -n "$(COREBOOT_OUTPUT_DIR)"
+	@test -n "$(CDK2_BUILD_DIR)"
+	@test -s "$(CDK2_PAYLOAD_FV)"
 	@test -z "$(KCONFIG_CONFIG)"
 	@test -z "$(obj)"
 	@test -z "$(top)"
@@ -23,20 +24,22 @@ coreboot-stage:
 	@test "$(origin AR)$(origin AS)$(origin LD)" = defaultdefaultdefault
 	@test "$(origin NM)$(origin OBJCOPY)$(origin OBJDUMP)" = undefinedundefinedundefined
 	@test "$(origin RANLIB)$(origin STRIP)" = undefinedundefined
-	@mkdir -p "$(COREBOOT_OUTPUT_DIR)/native"
-	@cp "$(COREBOOT_CDK2_PROFILE)" "$(COREBOOT_OUTPUT_DIR)/received.config"
-	@touch "$(COREBOOT_OUTPUT_DIR)/native/cdk2-coreboot-stage.elf"
+	@mkdir -p "$(CDK2_BUILD_DIR)/native"
+	@cp "$(COREBOOT_CDK2_PROFILE)" "$(CDK2_BUILD_DIR)/received.config"
+	@printf 'complete-image-with-fv\n' > "$(CDK2_BUILD_DIR)/native/cdk2-coreboot-image.elf"
 EOF
 git -C "$source_dir" add Makefile
 git -C "$source_dir" -c commit.gpgSign=false commit -q -m fixture
 revision=$(git -C "$source_dir" rev-parse HEAD)
+echo 'CONFIG_PAYLOAD_CDK2=y' > "$tmp/coreboot.config"
+printf 'admitted retained FV fixture\n' > "$tmp/retained.fv"
+retained_hash=$(sha256sum "$tmp/retained.fv" | awk '{print $1}')
 cat > "$tmp/gmake" <<EOF
 #!/bin/sh
 echo invoked > "$tmp/make-invoked"
 exec "$make_command" "\$@"
 EOF
 chmod +x "$tmp/gmake"
-echo 'CONFIG_PAYLOAD_CDK2=y' > "$tmp/coreboot.config"
 "$root/util/cdk2-config" "$tmp/coreboot.config" "$tmp/profile"
 COREBOOT_EXPORTS='COREBOOT_EXPORTS KCONFIG_CONFIG obj top src' \
 	KCONFIG_CONFIG=wrong obj=wrong top=wrong src=wrong \
@@ -44,14 +47,15 @@ COREBOOT_EXPORTS='COREBOOT_EXPORTS KCONFIG_CONFIG obj top src' \
 	RANLIB=wrong STRIP=wrong \
 	"$root/util/cdk2-build" "$source_dir" "$revision" \
 	"$tmp/coreboot.config" "$tmp/profile" "$tmp/output" \
-	"$tmp/gmake"
+	"$tmp/retained.fv" "$retained_hash" "$tmp/gmake"
 test -f "$tmp/make-invoked"
 cmp "$tmp/profile" "$tmp/output/received.config"
-test -f "$tmp/output/native/cdk2-coreboot-stage.elf"
+grep -qx 'complete-image-with-fv' "$tmp/output/native/cdk2-coreboot-image.elf"
 
 if "$root/util/cdk2-build" "$source_dir" \
 	0000000000000000000000000000000000000000 "$tmp/coreboot.config" \
-	"$tmp/profile" "$tmp/bad-revision" 2> "$tmp/error"; then
+	"$tmp/profile" "$tmp/bad-revision" "$tmp/retained.fv" \
+	"$retained_hash" 2> "$tmp/error"; then
 	echo 'mismatched CDK2 revision unexpectedly accepted' >&2
 	exit 1
 fi
@@ -59,22 +63,37 @@ grep -q 'revision mismatch' "$tmp/error"
 
 echo changed >> "$source_dir/Makefile"
 if "$root/util/cdk2-build" "$source_dir" "$revision" \
-	"$tmp/coreboot.config" "$tmp/profile" "$tmp/dirty" 2> "$tmp/error"; then
+	"$tmp/coreboot.config" "$tmp/profile" "$tmp/dirty" \
+	"$tmp/retained.fv" "$retained_hash" 2> "$tmp/error"; then
 	echo 'dirty CDK2 checkout unexpectedly accepted' >&2
 	exit 1
 fi
 grep -q 'tracked modifications' "$tmp/error"
+git -C "$source_dir" checkout -q -- Makefile
+
+if "$root/util/cdk2-build" "$source_dir" "$revision" \
+	"$tmp/coreboot.config" "$tmp/profile" "$tmp/bad-fv" \
+	"$tmp/retained.fv" \
+	0000000000000000000000000000000000000000000000000000000000000000 \
+	2> "$tmp/error"; then
+	echo 'mismatched retained FV digest unexpectedly accepted' >&2
+	exit 1
+fi
+grep -q 'retained FV digest mismatch' "$tmp/error"
 
 for board in config.emulation_qemu_x86_q35_smm_tseg config.starlabs_starbook_mtl; do
 	cp "$root/configs/$board" "$tmp/$board"
 	echo 'CONFIG_PAYLOAD_CDK2=y' >> "$tmp/$board"
+	echo 'CONFIG_CDK2_RETAINED_FV_PATH="/firmware/retained.fv"' >> "$tmp/$board"
 	"$make_command" -s -C "$root" DOTCONFIG="$tmp/$board" \
 		obj="$tmp/build-$board" olddefconfig
 	for symbol in PAYLOAD_CDK2 HANDOFF_COREBOOT_TABLES \
 		PAYLOAD_OWNS_PCI_DEVICES WANT_LINEAR_FRAMEBUFFER SMMSTORE; do
 		grep -qx "CONFIG_${symbol}=y" "$tmp/$board"
 	done
-	grep -qx 'CONFIG_CDK2_SOURCE_REVISION="b6c70863f4d0c8b893d561397fab8c4abb61d382"' \
+	grep -qx 'CONFIG_CDK2_SOURCE_REVISION="8bbabbd2557057f1b5112229a8b189fa99289d7c"' \
+		"$tmp/$board"
+	grep -qx 'CONFIG_CDK2_RETAINED_FV_SHA256="ca1ebfd0ff6c7c82935a4302c1ddc4cc418ed177756c678260dfb09527e1f50e"' \
 		"$tmp/$board"
 done
 

--- a/util/cdk2-build
+++ b/util/cdk2-build
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: GPL-2.0-only
 set -eu
 
-source_dir=${1:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
-revision=${2:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
-coreboot_config=${3:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
-profile=${4:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR}
-output_dir=${5:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR MAKE}
-make_command=${6:-make}
+source_dir=${1:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR RETAINED_FV RETAINED_FV_SHA256}
+revision=${2:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR RETAINED_FV RETAINED_FV_SHA256}
+coreboot_config=${3:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR RETAINED_FV RETAINED_FV_SHA256}
+profile=${4:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR RETAINED_FV RETAINED_FV_SHA256}
+output_dir=${5:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR RETAINED_FV RETAINED_FV_SHA256}
+retained_fv=${6:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR RETAINED_FV RETAINED_FV_SHA256}
+retained_fv_sha256=${7:?usage: cdk2-build SOURCE REVISION COREBOOT_CONFIG PROFILE OUTPUT_DIR RETAINED_FV RETAINED_FV_SHA256 MAKE}
+make_command=${8:-make}
 
 case "$revision" in
 	*[!0-9a-f]* )
@@ -44,6 +46,34 @@ test -z "$(git -C "$source_dir" status --porcelain --untracked-files=all)" || {
 	echo "CDK2 profile is missing or empty: $profile" >&2
 	exit 1
 }
+[ -s "$retained_fv" ] || {
+	echo "CDK2 retained FV is missing or empty: $retained_fv" >&2
+	exit 1
+}
+case "$retained_fv_sha256" in
+	*[!0-9a-f]* )
+		echo 'CDK2 retained FV SHA-256 must contain exactly 64 hexadecimal digits' >&2
+		exit 1
+		;;
+esac
+[ "${#retained_fv_sha256}" -eq 64 ] || {
+	echo 'CDK2 retained FV SHA-256 must contain exactly 64 hexadecimal digits' >&2
+	exit 1
+}
+if command -v sha256sum >/dev/null 2>&1; then
+	actual_fv_sha256=$(sha256sum "$retained_fv" | awk '{print $1}')
+elif command -v sha256 >/dev/null 2>&1; then
+	actual_fv_sha256=$(sha256 -q "$retained_fv")
+elif command -v shasum >/dev/null 2>&1; then
+	actual_fv_sha256=$(shasum -a 256 "$retained_fv" | awk '{print $1}')
+else
+	echo 'no supported SHA-256 utility found' >&2
+	exit 1
+fi
+[ "$actual_fv_sha256" = "$retained_fv_sha256" ] || {
+	echo "CDK2 retained FV digest mismatch: expected $retained_fv_sha256, found $actual_fv_sha256" >&2
+	exit 1
+}
 
 mkdir -p "$output_dir"
 # coreboot exports stage-specific compiler command lines.  They are not valid
@@ -57,5 +87,6 @@ exec env -u CC -u HOSTCC -u CFLAGS -u CPPFLAGS -u LDFLAGS \
 	"$make_command" -C "$source_dir" \
 	COREBOOT_CONFIG="$coreboot_config" \
 	COREBOOT_CDK2_PROFILE="$profile" \
-	COREBOOT_OUTPUT_DIR="$output_dir" \
-	coreboot-stage
+	CDK2_BUILD_DIR="$output_dir" \
+	CDK2_PAYLOAD_FV="$retained_fv" \
+	native-coreboot-image


### PR DESCRIPTION
Build and embed the complete cdk2-coreboot-image.elf instead of a stage-only payload. Require an explicit retained-FV path and pinned SHA-256, validate source revision and cleanliness, and invoke CDK2 native-coreboot-image in an out-of-tree build. Missing or mismatched inputs fail before payload composition.

Real Q35 validation passes CDK2 FV and ELF layout checks and reaches native DXE/BDS.