### PR TITLE
starlabs/starbook_mtl: add opt-in SPI flash console profile

### DIFF
--- a/configs/config.starlabs_starbook_mtl.spi_flash_console
+++ b/configs/config.starlabs_starbook_mtl.spi_flash_console
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# StarBook MTL debug-only SPI flash console overlay.
+# Apply after configs/config.starlabs_starbook_mtl with Kconfig merge tools.
+
+CONFIG_CONSOLE_SERIAL=y
+CONFIG_CONSOLE_CBMEM=y
+CONFIG_CONSOLE_SPI_FLASH=y
+CONFIG_CONSOLE_SPI_FLASH_BUFFER_SIZE=0x20000

--- a/configs/config.starlabs_starbook_mtl.spi_flash_console
+++ b/configs/config.starlabs_starbook_mtl.spi_flash_console
@@ -6,3 +6,7 @@ CONFIG_CONSOLE_SERIAL=y
 CONFIG_CONSOLE_CBMEM=y
 CONFIG_CONSOLE_SPI_FLASH=y
 CONFIG_CONSOLE_SPI_FLASH_BUFFER_SIZE=0x20000
+# Flash-console writes must remain possible while SMM protects the rest of
+# the flash.  These options are intentionally explicit in the debug overlay.
+CONFIG_BOOTMEDIA_SMM_BWP=n
+CONFIG_BOOTMEDIA_SMM_BWP_RUNTIME_OPTION=n

--- a/configs/overlays/starlabs_starbook_mtl_spi_flash_console.config
+++ b/configs/overlays/starlabs_starbook_mtl_spi_flash_console.config
@@ -1,12 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # StarBook MTL debug-only SPI flash console overlay.
 # Apply after configs/config.starlabs_starbook_mtl with Kconfig merge tools.
+#
+# The fragment deliberately lives below configs/overlays and does not use a
+# config.<board> name: util/abuild reserves that namespace for complete board
+# configurations.
 
 CONFIG_CONSOLE_SERIAL=y
 CONFIG_CONSOLE_CBMEM=y
 CONFIG_CONSOLE_SPI_FLASH=y
 CONFIG_CONSOLE_SPI_FLASH_BUFFER_SIZE=0x20000
-# Flash-console writes must remain possible while SMM protects the rest of
-# the flash.  These options are intentionally explicit in the debug overlay.
+
+# The SPI console writes after ramstage and therefore cannot coexist with SMM
+# write protection of the flash.  These options are intentionally explicit in
+# the debug overlay.
 CONFIG_BOOTMEDIA_SMM_BWP=n
 CONFIG_BOOTMEDIA_SMM_BWP_RUNTIME_OPTION=n

--- a/src/mainboard/starlabs/common/Kconfig
+++ b/src/mainboard/starlabs/common/Kconfig
@@ -59,6 +59,7 @@ menu "Star Labs Settings"
 
 config BOOTMEDIA_SMM_BWP
 	bool
+	default n if CONSOLE_SPI_FLASH
 	default y if SOC_INTEL_COMMON_BLOCK_SMM
 
 config BOOTMEDIA_SMM_BWP_RUNTIME_OPTION

--- a/util/testing/Makefile.mk
+++ b/util/testing/Makefile.mk
@@ -12,6 +12,7 @@ test-help help::
 	@echo  '  test-abuild          - Basic: Builds all platforms'
 	@echo  '  test-payloads        - Basic: Builds internal payloads'
 	@echo  '  test-cleanup         - Basic: Cleans coreboot directories'
+	@echo  '  test-starbook-mtl-spi-console - Validate the out-of-tree SPI console config'
 	@echo
 
 # junit.xml is a helper target to wrap builds that don't create junit.xml output
@@ -181,6 +182,9 @@ test-cleanup:
 	$(MAKE) -C src/soc/nvidia/tegra124/lp0 clean
 	$(MAKE) -C src/soc/nvidia/tegra210/lp0 clean
 
+test-starbook-mtl-spi-console:
+	util/testing/validate-starbook-mtl-spi-console-test.sh
+
 .PHONY: test-basic test-lint test-abuild test-payloads
-.PHONY: test-tools test-cleanup test-help
+.PHONY: test-tools test-cleanup test-help test-starbook-mtl-spi-console
 .PHONY: lint lint-stable what-jenkins-does

--- a/util/testing/validate-starbook-mtl-spi-console-test.sh
+++ b/util/testing/validate-starbook-mtl-spi-console-test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+temporary=$(mktemp -d)
+trap 'rm -rf "$temporary"' EXIT
+
+cd "$temporary"
+"$root/util/validate-starbook-mtl-spi-console.sh"
+
+printf '%s\n' 'StarBook MTL out-of-tree SPI console validation passed'

--- a/util/validate-starbook-mtl-spi-console.sh
+++ b/util/validate-starbook-mtl-spi-console.sh
@@ -4,10 +4,18 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 fmd="$root/src/mainboard/starlabs/starfighter/variants/mtl/board.fmd"
-overlay="$root/configs/config.starlabs_starbook_mtl.spi_flash_console"
+overlay="$root/configs/overlays/starlabs_starbook_mtl_spi_flash_console.config"
 base="$root/configs/config.starlabs_starbook_mtl"
 resolved=$(mktemp)
 trap 'rm -f "$resolved"' EXIT
+
+# abuild treats every top-level configs/config.<board>* file as a complete
+# configuration.  Keep this opt-in fragment outside that discovery namespace.
+if find "$root/configs" -maxdepth 1 \
+	-name 'config.starlabs_starbook_mtl*' ! -path "$base" | grep -q .; then
+	printf '%s\n' 'error: SPI console overlay collides with abuild config discovery' >&2
+	exit 1
+fi
 
 grep -Eq 'SMMSTORE@0x30000[[:space:]]+0x80000' "$fmd"
 grep -Eq 'CONSOLE@0xB0000[[:space:]]+0x20000' "$fmd"

--- a/util/validate-starbook-mtl-spi-console.sh
+++ b/util/validate-starbook-mtl-spi-console.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fmd="$root/src/mainboard/starlabs/starfighter/variants/mtl/board.fmd"
+overlay="$root/configs/config.starlabs_starbook_mtl.spi_flash_console"
+base="$root/configs/config.starlabs_starbook_mtl"
+
+grep -Eq 'SMMSTORE@0x30000[[:space:]]+0x80000' "$fmd"
+grep -Eq 'CONSOLE@0xB0000[[:space:]]+0x20000' "$fmd"
+grep -q '^CONFIG_CONSOLE_SERIAL=y$' "$overlay"
+grep -q '^CONFIG_CONSOLE_CBMEM=y$' "$overlay"
+grep -q '^CONFIG_CONSOLE_SPI_FLASH=y$' "$overlay"
+grep -q '^CONFIG_CONSOLE_SPI_FLASH_BUFFER_SIZE=0x20000$' "$overlay"
+if grep -q '^CONFIG_CONSOLE_SPI_FLASH=y$' "$base"; then
+	printf '%s\n' 'error: normal StarBook MTL profile must keep SPI flash console disabled' >&2
+	exit 1
+fi
+
+printf '%s\n' 'StarBook MTL SPI console layout/profile validation passed'

--- a/util/validate-starbook-mtl-spi-console.sh
+++ b/util/validate-starbook-mtl-spi-console.sh
@@ -3,7 +3,7 @@
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-fmd="$root/src/mainboard/starlabs/starfighter/variants/mtl/board.fmd"
+fmd="$root/src/mainboard/starlabs/starbook/variants/mtl/board.fmd"
 overlay="$root/configs/overlays/starlabs_starbook_mtl_spi_flash_console.config"
 base="$root/configs/config.starlabs_starbook_mtl"
 resolved=$(mktemp)

--- a/util/validate-starbook-mtl-spi-console.sh
+++ b/util/validate-starbook-mtl-spi-console.sh
@@ -6,6 +6,8 @@ root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 fmd="$root/src/mainboard/starlabs/starfighter/variants/mtl/board.fmd"
 overlay="$root/configs/config.starlabs_starbook_mtl.spi_flash_console"
 base="$root/configs/config.starlabs_starbook_mtl"
+resolved=$(mktemp)
+trap 'rm -f "$resolved"' EXIT
 
 grep -Eq 'SMMSTORE@0x30000[[:space:]]+0x80000' "$fmd"
 grep -Eq 'CONSOLE@0xB0000[[:space:]]+0x20000' "$fmd"
@@ -13,9 +15,25 @@ grep -q '^CONFIG_CONSOLE_SERIAL=y$' "$overlay"
 grep -q '^CONFIG_CONSOLE_CBMEM=y$' "$overlay"
 grep -q '^CONFIG_CONSOLE_SPI_FLASH=y$' "$overlay"
 grep -q '^CONFIG_CONSOLE_SPI_FLASH_BUFFER_SIZE=0x20000$' "$overlay"
+grep -q '^CONFIG_BOOTMEDIA_SMM_BWP=n$' "$overlay"
+grep -q '^CONFIG_BOOTMEDIA_SMM_BWP_RUNTIME_OPTION=n$' "$overlay"
 if grep -q '^CONFIG_CONSOLE_SPI_FLASH=y$' "$base"; then
 	printf '%s\n' 'error: normal StarBook MTL profile must keep SPI flash console disabled' >&2
 	exit 1
 fi
+
+# Resolve the real Kconfig result from the maintained base profile plus the
+# opt-in overlay; do not treat the fragment text itself as validation.
+cp "$base" "$resolved"
+cat "$overlay" >> "$resolved"
+make -s olddefconfig KCONFIG_CONFIG="$resolved"
+grep -q '^CONFIG_CONSOLE_SERIAL=y$' "$resolved"
+grep -q '^CONFIG_CONSOLE_CBMEM=y$' "$resolved"
+grep -q '^CONFIG_CONSOLE_SPI_FLASH=y$' "$resolved"
+grep -q '^CONFIG_CONSOLE_SPI_FLASH_BUFFER_SIZE=0x20000$' "$resolved"
+! grep -q '^CONFIG_BOOTMEDIA_SMM_BWP=y$' "$resolved"
+! grep -q '^CONFIG_BOOTMEDIA_SMM_BWP_RUNTIME_OPTION=y$' "$resolved"
+grep -q '^CONFIG_BOOT_DEVICE_SPI_FLASH=y$' "$resolved"
+grep -q '^CONFIG_BOOT_DEVICE_SPI_FLASH_RW_NOMMAP_EARLY=y$' "$resolved"
 
 printf '%s\n' 'StarBook MTL SPI console layout/profile validation passed'

--- a/util/validate-starbook-mtl-spi-console.sh
+++ b/util/validate-starbook-mtl-spi-console.sh
@@ -26,7 +26,7 @@ fi
 # opt-in overlay; do not treat the fragment text itself as validation.
 cp "$base" "$resolved"
 cat "$overlay" >> "$resolved"
-make -s olddefconfig KCONFIG_CONFIG="$resolved"
+make -s -C "$root" olddefconfig KCONFIG_CONFIG="$resolved"
 grep -q '^CONFIG_CONSOLE_SERIAL=y$' "$resolved"
 grep -q '^CONFIG_CONSOLE_CBMEM=y$' "$resolved"
 grep -q '^CONFIG_CONSOLE_SPI_FLASH=y$' "$resolved"


### PR DESCRIPTION
## Summary

- add an opt-in StarBook MTL SPI-flash-console configuration overlay
- retain serial and CBMEM consoles
- disable SMM boot-media write protection only in the flashconsole debug profile
- validate resolved Kconfig dependencies and exact FMAP console geometry

The normal StarBook MTL profile and board FMAP are unchanged. CDK2 does not write SPI directly; this enables Coreboot's existing append-only `CONSOLE` FMAP logger.

## Layout

- `SMMSTORE`: `0x30000 + 0x80000`
- `CONSOLE`: `0xB0000 + 0x20000`

The regions are adjacent and non-overlapping.

## Validation

An independent clean-room worker reproduced the exact tip and passed:

- `util/validate-starbook-mtl-spi-console.sh`
- merged-overlay `olddefconfig` resolution
- normal-profile `olddefconfig` resolution
- exact serial/CBMEM/SPI/buffer/write-dependency assertions
- BWP-disabled debug and BWP-enabled normal-profile assertions
- FMAP geometry checks
- `git diff --check`

A full board image build was not run because the isolated checkout lacks the external Star Labs blobs/toolchain inputs.