### PR TITLE
starlabs/starbook_mtl: audit PCI bus-master ownership

### DIFF
--- a/configs/policies/starlabs_starbook_mtl_busmaster_ownership.tsv
+++ b/configs/policies/starlabs_starbook_mtl_busmaster_ownership.tsv
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: GPL-2.0-only
+devicetree	f5b8925312dfae03d37e43c1e7ee943a5997324c3595b8e9b2ea11d3f1662559	generated StarBook MTL static devicetree
+# kind  state  owner  class  source  context-sha256  review note
+#
+# The site digest covers the matching line and its two neighbouring lines on
+# either side. The audit regenerates this inventory from the exact source list
+# selected by config.starlabs_starbook_mtl. Keep disable and dormant sites: a
+# changed Kconfig guard or a changed operation must be reviewed, not disappear.
+
+# Resolved policy inputs used by the classifications below.
+config	CONFIG_PCI_ALLOW_BUS_MASTER_ANY_DEVICE	y	broad compatibility policy remains enabled
+config	CONFIG_PCI_SET_BUS_MASTER_PCI_BRIDGES	y	bridge forwarding is enabled
+config	CONFIG_PAYLOAD_OWNS_PCI_DEVICES	y	EDK2 owns endpoint devices at handoff
+config	CONFIG_RUN_FSP_GOP	y	FSP initializes graphics
+config	CONFIG_NO_GFX_INIT	n	coreboot graphics init remains enabled
+config	CONFIG_TCG_OPAL_S3_UNLOCK	y	S3 OPAL NVMe path is compiled
+config	CONFIG_CONSOLE_SERIAL	n	release profile does not initialize debug UART
+
+# Site rows are updated only after reviewing audit-reported inventory drift.
+site	enable	coreboot	bridge-resource	src/device/pci_device.c	e8db683ee4b73bebb6751b0a38ec681488f5bf761340ed1f33cc76cb5e8e0a52	PCI bridge forwarding selected by PCI_SET_BUS_MASTER_PCI_BRIDGES
+site	enable	coreboot	system-class	src/device/pci_device.c	da3028e8ea2818b4b2465e84f3b8b644ef0e07099a163f0cf88e835078bc1851	system-class device selected by broad ANY_DEVICE compatibility
+site	disable	coreboot	endpoint-helper	src/device/pci_device.c	a56e73f3aa9d0d24734523354be67d276e5f96b09e9a8d27d63b317351e916f0	generic endpoint bus-master disable helper
+site	enable	coreboot	opal-s3-nvme	src/security/tcg/opal_s3/opal_nvme.c	27380af85a4a02f5422c34384c3df34703335990d6751c7eb758465d15936df4	S3 unlock enables the NVMe endpoint and currently retains it after success
+site	disable	coreboot	opal-s3-error	src/security/tcg/opal_s3/opal_nvme.c	3bd9a32113f13daf6d1faec605ab2a50ad23555b4ee068db63273c5505044d89	invalid-BAR failure clears NVMe memory decode and BME
+site	disable	coreboot	cse-early	src/soc/intel/common/block/cse/cse.c	a8688fb887ff0e64d554ba314718c4af4e77489bc6768926ba5aa46168b3e178	clear old HECI decode before programming temporary BAR
+site	enable	coreboot	cse-early	src/soc/intel/common/block/cse/cse.c	4e55888af84a1d730661ee75b66ebeedd1b11f1f55e6dd521f077ac9169fae12	enable HECI temporary BAR for pre-memory CSE traffic
+site	enable	coreboot	cse-state	src/soc/intel/common/block/cse/cse.c	8eb9fc54d0d3400399c86017a5c5a74bcd0f37f02b2a7a07de622a369d7f00e0	enable CSE device while leaving device-idle state
+site	disable	coreboot	cse-state	src/soc/intel/common/block/cse/cse.c	4e712757b259fb141d09951b8f57345e423898081b8d96e5089c62c0f1cca713	clear CSE decode and BME when entering device-idle
+site	dormant	payload	dsp-endpoint	src/soc/intel/common/block/dsp/dsp.c	ad9480e8c59d02dc547f53c75d1bec7d8e6951c6fb7b3966300c892f72388f85	request branch is not selected because PAYLOAD_OWNS_PCI_DEVICES is set
+site	disable	coreboot	fast-spi-early	src/soc/intel/common/block/fast_spi/fast_spi.c	e0797ca74f81be05b55bd41c63e536fe482a9b574c432ce101a47dfcc046a9e0	clear old SPI decode before programming temporary BAR
+site	enable	coreboot	fast-spi-early	src/soc/intel/common/block/fast_spi/fast_spi.c	219c37e5da0dd6b71c88239a3ade56a6a4fd866eb5b02c5a91366b9892247e84	enable SPI temporary BAR during bootblock initialization
+site	enable	coreboot	graphics-endpoint	src/soc/intel/common/block/graphics/graphics.c	62b3859b99c2807a8b180fdcda3927733386fd24dec2cbac638e200d062f19e1	graphics init directly enables BME because NO_GFX_INIT is not set
+site	enable	coreboot	graphics-endpoint	src/soc/intel/common/block/graphics/graphics.c	49b3c88069bb8c2b1bc7721fd90a67dc98fd577476ae1ce5a6b5ea9049630ca2	graphics final requests BME under broad ANY_DEVICE compatibility
+site	dormant	coreboot	gspi-early	src/soc/intel/common/block/gspi/gspi.c	bb3eb181d7e689635f62e3daf5959b6ae57cc9a254f8506ac90087cec912c18a	compiled simple-device setter; StarBook MTL has no GSPI early-init owner
+site	dormant	coreboot	gspi-runtime	src/soc/intel/common/block/gspi/gspi.c	eef255159265a1ef06c232d0241b8f5d9a2a9084c433ccd46b7468ee023603ac	compiled runtime setter; StarBook MTL has no enabled GSPI device
+site	dormant	payload	hda-endpoint	src/soc/intel/common/block/hda/hda.c	bd05eb8e1069f659081e2a2d835a8212a21defb0cb0bc0c463cf558298ea4b8f	request branch is not selected because PAYLOAD_OWNS_PCI_DEVICES is set
+site	dormant	coreboot	i2c-early	src/soc/intel/common/block/i2c/i2c.c	cf70e7fdf3757858e95f87017016754620e8491ec40bf17ccd80db725166a829	compiled setter; StarBook MTL I2C configuration does not set early_init
+site	enable	coreboot	p2sb-platform	src/soc/intel/common/block/p2sb/p2sblib.c	55fd4b44ac35559e32a141764b271ed823a88921b0ac31aa83cad2bd21afba83	enable P2SB PCR BAR during platform initialization
+site	enable	coreboot	pcie-bridge	src/soc/intel/common/block/pcie/pcie.c	3740156074949d85d903ce7489e8e5906309a066ebab547679e1a9cee777c734	enable forwarding on initialized PCH PCIe root ports
+site	dormant	payload	sata-endpoint	src/soc/intel/common/block/sata/sata.c	4fcc1af0b51d28295ef75f885a9a424b7267b535c552a8d1d2dfec450a5ff7ee	request branch is not selected because PAYLOAD_OWNS_PCI_DEVICES is set
+site	disable	coreboot	smm-sweep	src/soc/intel/common/block/smm/smihandler.c	c963b3612d4ed892a1a175be024ee700ac0f86931101c5977abc0b376f48f032	SMM sleep path clears endpoint bus mastering
+site	capability	coreboot	uart-controller	src/soc/intel/common/block/uart/uart.c	5cfa3202e2fa328644a5d9154f563419f7dc1687ab23c21e61912636c68c4dae	compiled UART enable mask; release profile has CONSOLE_SERIAL disabled
+site	disable	coreboot	pmc-bootblock	src/soc/intel/meteorlake/bootblock/soc_die.c	f8e1370d949c9f847522de490bfe5c25b8802a57c1a093d7811b312a1d6e1f9b	clear old PMC decode before assigning PWRMBASE
+site	enable	coreboot	pmc-bootblock	src/soc/intel/meteorlake/bootblock/soc_die.c	f9853bc467e0140d56888ac17ab74f765aac28e2c415f160efe753077a2dc4fe	enable PMC PWRMBASE in bootblock
+
+# Configured preprocessor expansion. The state describes the operation, not
+# whether its containing function is called; the site rows above record dormant
+# board paths. Unknown command-register rows have a proven command offset but
+# an indirect or non-asserting BME value. Unknown-overlap rows are mutators whose
+# configured byte range could not be proven disjoint from command bytes 4-5;
+# both kinds remain pinned to their exact source line and expanded statement.
+site	disable	coreboot	dsp-finalize	src/soc/intel/common/block/dsp/dsp.c	e403432dba9e478b8e8810a3f30dd2438d0c95123f2717fe048ad3ba0867500f	payload handoff clears DSP bus mastering
+site	disable	coreboot	hda-finalize	src/soc/intel/common/block/hda/hda.c	6987cd95098ec47fb89ec9c7eb6a549fe815c9d4af5301407bbada42f0a27a2a	payload handoff clears HDA bus mastering
+site	disable	coreboot	i2c-finalize	src/soc/intel/common/block/i2c/i2c.c	2aa08ee29af092361f8809e1ee68e7c3ce7d0bd52703733e872edf972e5655c2	payload handoff clears I2C bus mastering
+site	disable	coreboot	sata-finalize	src/soc/intel/common/block/sata/sata.c	c7507c96e3e9dfacbaccbadd6f689e2fd830a7a748f394b48400b3c65ee8433b	payload handoff clears SATA bus mastering
+site	disable	coreboot	thunderbolt-finalize	src/soc/intel/common/feature/finalize/finalize.c	30ced1cfdd3ac2a3ba9e723bb7c42868e3d1d07d4230adde7f5685104332eea5	payload handoff clears Thunderbolt bus mastering
+site	disable	coreboot	xhci-finalize	src/soc/intel/common/block/xhci/xhci.c	b82e3c86e538edad62870a922e11acab952ea98212a2adc63c954dd91eedd42a	payload handoff clears xHCI bus mastering
+expanded	disable	coreboot	command-register	bootblock	src/soc/intel/meteorlake/bootblock/soc_die.c	6c451b2bbd7892bf2d7d381e13b15bcb53ccf5bd9470215bf304f3a076631287	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/device/pci_device.c	5b8aeb7a4ea1ba4a5a442d6901aafa1a296b507d3e19811f44c02aea6c14f63a	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/device/pci_device.c	fbffe39b44edf2888df0a330777f8d169da6d0255a7b5614f51d1387557d008f	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/soc/intel/common/block/cse/cse.c	f3b3f26a38aee45e45566f6ee88436a2de4dd153dbdce3e403cc7b2f658735f4	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/soc/intel/common/block/dsp/dsp.c	4128f29f52ffcab8198673f6eef0197f95db8ed1f9d0e7bafddedc3fcec47604	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/soc/intel/common/block/hda/hda.c	d9007f96a0c19d281ddb40fa185f9c4db0c20158151a02237106c7fedb508c48	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/soc/intel/common/block/i2c/i2c.c	24dcfc79ea3607725cf67010589a140747f7e9c1c835cb2041592c8dd66d02b3	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/soc/intel/common/block/sata/sata.c	b8343abcda9e0a988df2c5d932acaed78df5362f2232b9faa5d0c7c3a407c98e	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/soc/intel/common/block/xhci/xhci.c	b7b6e3f035f045b12d801b8276644ba069834a63a6fa0c802cec88b01721fd59	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	ramstage	src/soc/intel/common/feature/finalize/finalize.c	a0812cc45a5839e0d85627123433485d9ffdaadd21a3489bacc14b440464fcfa	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	romstage	src/soc/intel/common/block/cse/cse.c	f3b3f26a38aee45e45566f6ee88436a2de4dd153dbdce3e403cc7b2f658735f4	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	smm	src/security/tcg/opal_s3/opal_nvme.c	eb2bcb3015e737a5af16d5412ad1941de67b922846418d50f0a24f32dd5d0457	reviewed stage-specific preprocessor expansion
+expanded	dormant	payload	command-register	ramstage	src/soc/intel/common/block/dsp/dsp.c	443d4d9de130f06d77a13ed306272c98820b124453a2773d0e3a9e57b4aea8a7	reviewed stage-specific preprocessor expansion
+expanded	dormant	payload	command-register	ramstage	src/soc/intel/common/block/hda/hda.c	f539615c3dc96475dc3976308942904c20092d2eb071e9d52aec9494a6bf8b65	reviewed stage-specific preprocessor expansion
+expanded	dormant	payload	command-register	ramstage	src/soc/intel/common/block/sata/sata.c	387a96afe39497f9ab21732b1315c7924ee5e9b49fcce8dd47a71f983a8cf8e1	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	bootblock	src/include/device/pci.h	e95494e6228ebb0eb9eef2991ca46676ddbc6109897a77a10eb07a0de694cece	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	bootblock	src/soc/intel/common/block/fast_spi/fast_spi.c	85efe4748d77cde39972779442478434b2637e7eb9cbace2c1d5897d8548bdb3	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	bootblock	src/soc/intel/common/block/gspi/gspi.c	b55c38263da6fabfe80751aaf1b2c99ce568992f852e1d0020f5467ac4f53dda	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	bootblock	src/soc/intel/common/block/i2c/i2c.c	2ee8d22c782bbbf95aac4dffa9421ed4aa73021e52c13a1dcee522c074349f96	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	bootblock	src/soc/intel/common/block/p2sb/p2sblib.c	1c16e71bcf07d8de8556a111b3dda51c2a00354b6f4d2da4980bdfa98cc1ee77	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	bootblock	src/soc/intel/common/block/uart/uart.c	1ca912ec6e1dee714c06004a64f4a3f66ccc627ca79e1df99af6f3ae720f3ca1	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	bootblock	src/soc/intel/meteorlake/bootblock/soc_die.c	b45b66660bad011f18300910e010d1cbe73b478f84bd3567d16b029e864d5e80	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	postcar	src/include/device/pci.h	e95494e6228ebb0eb9eef2991ca46676ddbc6109897a77a10eb07a0de694cece	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	postcar	src/soc/intel/common/block/fast_spi/fast_spi.c	85efe4748d77cde39972779442478434b2637e7eb9cbace2c1d5897d8548bdb3	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	postcar	src/soc/intel/common/block/gspi/gspi.c	b55c38263da6fabfe80751aaf1b2c99ce568992f852e1d0020f5467ac4f53dda	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	postcar	src/soc/intel/common/block/i2c/i2c.c	2ee8d22c782bbbf95aac4dffa9421ed4aa73021e52c13a1dcee522c074349f96	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	postcar	src/soc/intel/common/block/uart/uart.c	1ca912ec6e1dee714c06004a64f4a3f66ccc627ca79e1df99af6f3ae720f3ca1	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/device/pci_device.c	289795d49df43833779ede8be0a73f78f2db314ad8de00a985afd8aeebeda723	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/device/pci_device.c	c3e64f27810778c97637a9d32a6bc9b54463fe89066fe82c4e3dcae7a37d6444	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/include/device/pci.h	87a2ea553b44f1fe388c6fd3b9fddeaf723edfa2559122e750555e529a15bfb1	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/include/device/pci.h	e95494e6228ebb0eb9eef2991ca46676ddbc6109897a77a10eb07a0de694cece	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/cse/cse.c	ca2a54eca527bb7b79c6e8f2b5e18bcb5da7b6ec0c32c18fc072f85c5ec22e55	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/cse/cse.c	d5b7737de88920a6f24773d772ae8fd696cd394ffbdb2cb5969180970e584789	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/fast_spi/fast_spi.c	85efe4748d77cde39972779442478434b2637e7eb9cbace2c1d5897d8548bdb3	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/graphics/graphics.c	5743d97badb9c99e0852ea00aeea3b35d16749aea3f2130d7d1b94bec61896b4	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/graphics/graphics.c	81fb2405eeff5689080c2d319bbef53f8d1a7727f2e8733ed807c9415cb5acbe	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/gspi/gspi.c	d6940bb3cec882b703f34a5bc288369c9136edd4d450dd8ce24675f6b4413e0f	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/p2sb/p2sblib.c	1c16e71bcf07d8de8556a111b3dda51c2a00354b6f4d2da4980bdfa98cc1ee77	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/pcie/pcie.c	e337c90eac1e63343f0faaa8c367e0461ac9150f1cc9c64420cec6c11cd0e76b	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	ramstage	src/soc/intel/common/block/uart/uart.c	1ca912ec6e1dee714c06004a64f4a3f66ccc627ca79e1df99af6f3ae720f3ca1	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	romstage	src/include/device/pci.h	e95494e6228ebb0eb9eef2991ca46676ddbc6109897a77a10eb07a0de694cece	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	romstage	src/soc/intel/common/block/cse/cse.c	ca2a54eca527bb7b79c6e8f2b5e18bcb5da7b6ec0c32c18fc072f85c5ec22e55	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	romstage	src/soc/intel/common/block/cse/cse.c	d5b7737de88920a6f24773d772ae8fd696cd394ffbdb2cb5969180970e584789	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	romstage	src/soc/intel/common/block/fast_spi/fast_spi.c	85efe4748d77cde39972779442478434b2637e7eb9cbace2c1d5897d8548bdb3	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	romstage	src/soc/intel/common/block/gspi/gspi.c	b55c38263da6fabfe80751aaf1b2c99ce568992f852e1d0020f5467ac4f53dda	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	romstage	src/soc/intel/common/block/i2c/i2c.c	2ee8d22c782bbbf95aac4dffa9421ed4aa73021e52c13a1dcee522c074349f96	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	romstage	src/soc/intel/common/block/p2sb/p2sblib.c	1c16e71bcf07d8de8556a111b3dda51c2a00354b6f4d2da4980bdfa98cc1ee77	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	romstage	src/soc/intel/common/block/uart/uart.c	1ca912ec6e1dee714c06004a64f4a3f66ccc627ca79e1df99af6f3ae720f3ca1	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	smm	src/include/device/pci.h	e95494e6228ebb0eb9eef2991ca46676ddbc6109897a77a10eb07a0de694cece	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	smm	src/security/tcg/opal_s3/opal_nvme.c	3484e097b81f0480b587ba2ba046a7ba8558013d832058e76ee873f805f2b3fe	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	smm	src/soc/intel/common/block/fast_spi/fast_spi.c	85efe4748d77cde39972779442478434b2637e7eb9cbace2c1d5897d8548bdb3	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	smm	src/soc/intel/common/block/p2sb/p2sblib.c	1c16e71bcf07d8de8556a111b3dda51c2a00354b6f4d2da4980bdfa98cc1ee77	reviewed stage-specific preprocessor expansion
+expanded	enable	coreboot	command-register	smm	src/soc/intel/common/block/uart/uart.c	1ca912ec6e1dee714c06004a64f4a3f66ccc627ca79e1df99af6f3ae720f3ca1	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	bootblock	src/device/pci_early.c	0d3946a3217baf9be7abf1ee471ecc4c465b4a9639f463d7c2623216bd78b0b7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	bootblock	src/device/pci_early.c	54c9a8df282a78cfa5c26ee04313f7b5e88ff433e81198e5efd92a787595a23b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	bootblock	src/soc/intel/common/block/fast_spi/fast_spi.c	a14e27a629dfd494c3520810c26ea96f1e3816748993246682bfaef589af997b	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	bootblock	src/soc/intel/common/block/smbus/smbus_early.c	38db2af7edfac9fe88d87899c48920e725c2e9295eebb7b23951cb302b18d206	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	postcar	src/device/pci_early.c	0d3946a3217baf9be7abf1ee471ecc4c465b4a9639f463d7c2623216bd78b0b7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	postcar	src/device/pci_early.c	54c9a8df282a78cfa5c26ee04313f7b5e88ff433e81198e5efd92a787595a23b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	postcar	src/soc/intel/common/block/fast_spi/fast_spi.c	a14e27a629dfd494c3520810c26ea96f1e3816748993246682bfaef589af997b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/device/device.c	8b5c2baa79ed1b7d5962de8f54ab919806fe4de10e8004bc284fc272c096cf02	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/device/device.c	940264b535977f132de4f2dde26b17a9f1e79c253aea61af4cf95844e2c28c02	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/device/pci_device.c	1618afe4cbf5a13b7d24f335f41461726ed4c65cd004c1a73f499cca2c49a2ce	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/device/pci_device.c	1d51ef6dffcca6e5ecacf8e4db3ba6ed74a44be9bdae4e7f08ace449ea475219	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/device/pci_device.c	25c976be4413d4b080113040135f6e643d4a52f96a39848e0cedb2fcef9a6ece	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/device/pci_device.c	540af1a7a08240056e5adacbe975507eadfdce20b3994e14f23dc4b6c27c3e11	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/device/pci_device.c	8be19410053c1562fc12fb772ff29b25e27f2d7cd117cdb3e37ce041ffe563c5	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/soc/intel/common/block/cse/cse.c	4aa4337f2f3bac386c48f423490eddf55008727d4e08e1d7b6c138774e420de3	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/soc/intel/common/block/fast_spi/fast_spi.c	a14e27a629dfd494c3520810c26ea96f1e3816748993246682bfaef589af997b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/soc/intel/common/block/pcie/pcie.c	3743f8f0b934d81f50e06f6f128d47a61769ad2131b4d7734eca62c06f2c4fd2	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/soc/intel/meteorlake/crashlog.c	5ed9544abbe5611b8be04e519003739071d60005ddcbf444bdad87dd5690eb6e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	ramstage	src/soc/intel/meteorlake/crashlog.c	e35c224ce519ef4be7a05eec58f02d23b2fb8be5b2e17b99e06397a2cb0fe0a8	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	romstage	src/device/pci_early.c	0d3946a3217baf9be7abf1ee471ecc4c465b4a9639f463d7c2623216bd78b0b7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	romstage	src/device/pci_early.c	54c9a8df282a78cfa5c26ee04313f7b5e88ff433e81198e5efd92a787595a23b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	romstage	src/soc/intel/common/block/cse/cse.c	4aa4337f2f3bac386c48f423490eddf55008727d4e08e1d7b6c138774e420de3	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	romstage	src/soc/intel/common/block/fast_spi/fast_spi.c	a14e27a629dfd494c3520810c26ea96f1e3816748993246682bfaef589af997b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	romstage	src/soc/intel/common/block/graphics/early_graphics.c	596383dbb052fd0423021de7697b1e30280db56aac6806693d3b5dbffeec2cfc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	romstage	src/soc/intel/common/block/graphics/early_graphics.c	cba0891542ed039de61daf1c9bf1ed8f1cbce748914326e6df914a04d86b5fcf	reviewed stage-specific preprocessor expansion
+expanded	disable	coreboot	command-register	romstage	src/soc/intel/common/block/smbus/smbus_early.c	38db2af7edfac9fe88d87899c48920e725c2e9295eebb7b23951cb302b18d206	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	smm	src/soc/intel/common/block/fast_spi/fast_spi.c	a14e27a629dfd494c3520810c26ea96f1e3816748993246682bfaef589af997b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	command-register	smm	src/soc/intel/common/block/smm/smihandler.c	129b9ce34298ff47461e80a67dadfd11a1d9a45797c827970137d12a5bb485a7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/arch/x86/include/arch/pci_io_cfg.h	275198348b95cbe07edf36ac95548cd50bbefc2153891c7f33d8357d64430ffc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/arch/x86/include/arch/pci_io_cfg.h	bf04b6f9a98c062c7d542227fd0e92daae71d348fd843d4825af32d9ec194f22	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/arch/x86/include/arch/pci_io_cfg.h	cb3901c03bc032b5abe3e8ccc5aff11d7d507b8311029c8963093e5d840113ea	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_mmio_cfg.h	8ee08caf604fc2ef0960c075ad31c3b7a8bd2356d352d3b879559bca589a753b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_mmio_cfg.h	a654efb3fa9d95ea55e0ad7f51e05b91b42b75c5be480924f555a54bdf2ee4b6	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_mmio_cfg.h	e3003cf2cd9d460792ac31e83c6df47b01f093b0f32064e42efcac4e41cd300f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	0286eeaba27765b3df1ae9833b1074b17220067a22c49084d8738fdea2179033	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	1a391658c9e7d5955f659ad68657f7ee62eff73e18e8584ee5623b395d5a3860	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	2309570a2fe3150c6f922e0d8be09bbb28d4ae6290c277ea8d0fb1b8df43c3ec	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	50b199863d4971ecb154b83b8c4f7e3274a68d981586f73be703a8e28daabcc7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	59264b4d1762b065125b51cb7217b4c7520a8f29d3c4a4687c51be0a78ef1dfc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	5ef6bfec530e47ebdd6aba97df657abdc910bbdc4b27035964d4e3e9aa8cd465	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	b2889c0b244c02fff8cdbd98ff99f8dd640127cda2f89551fb5b50eb2055cb7a	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	cf5365a2ebe3d33f46cadf8e454be36f27986fcf50723fea1735ffe63293626e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	d4cfd5ffe7cff44a9eeabb7576351f3b8ec1995959ea497bd053480e3c5d3acc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	de9520297afeefaf1750d52cdd2e8abea7e948cd35487a4457e75d9a122fb16d	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	f2111431a33603eb740efa422a5759ea5319bcf6a70b85234a3ff0ba65aec49f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/include/device/pci_ops.h	f21e17ed8ddd7c3ee3c25a7e51121028ff0e6e6bbc795772bbc5947319845e19	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/soc/intel/common/block/lpc/lpc_lib.c	b690951c9358f9dace55c77bc15e4994c998f69ca1566140c97c75126f1600dd	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/soc/intel/common/block/lpc/lpc_lib.c	f7d0aa29897bde0209c1a8149aeda9a2b27a80890b266dfa0e5dbcb3ba7645aa	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/soc/intel/common/block/p2sb/p2sb.c	180a8bfcf8cf0f73097f58682042b676ebf040efabf3cb191343a23f6cfd77cb	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/soc/intel/common/block/p2sb/p2sblib.c	1c9462dfbf6b5d78fe63ac8bbc928208fc0e8d66f632bcb5a69fedb8b7d26d69	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/soc/intel/common/block/systemagent/systemagent_early.c	b36d60726fcea8a94dea418eb188fa43682e3fdbe3dd5324ea6a7290cbb6c0d5	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	bootblock	src/soc/intel/common/block/systemagent/systemagent_early.c	c658d71703670ced656439daf3c760ee708779e1398646e862c1ce32b0b5a292	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/arch/x86/include/arch/pci_io_cfg.h	275198348b95cbe07edf36ac95548cd50bbefc2153891c7f33d8357d64430ffc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/arch/x86/include/arch/pci_io_cfg.h	bf04b6f9a98c062c7d542227fd0e92daae71d348fd843d4825af32d9ec194f22	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/arch/x86/include/arch/pci_io_cfg.h	cb3901c03bc032b5abe3e8ccc5aff11d7d507b8311029c8963093e5d840113ea	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_mmio_cfg.h	8ee08caf604fc2ef0960c075ad31c3b7a8bd2356d352d3b879559bca589a753b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_mmio_cfg.h	a654efb3fa9d95ea55e0ad7f51e05b91b42b75c5be480924f555a54bdf2ee4b6	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_mmio_cfg.h	e3003cf2cd9d460792ac31e83c6df47b01f093b0f32064e42efcac4e41cd300f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	0286eeaba27765b3df1ae9833b1074b17220067a22c49084d8738fdea2179033	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	1a391658c9e7d5955f659ad68657f7ee62eff73e18e8584ee5623b395d5a3860	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	2309570a2fe3150c6f922e0d8be09bbb28d4ae6290c277ea8d0fb1b8df43c3ec	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	50b199863d4971ecb154b83b8c4f7e3274a68d981586f73be703a8e28daabcc7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	59264b4d1762b065125b51cb7217b4c7520a8f29d3c4a4687c51be0a78ef1dfc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	5ef6bfec530e47ebdd6aba97df657abdc910bbdc4b27035964d4e3e9aa8cd465	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	b2889c0b244c02fff8cdbd98ff99f8dd640127cda2f89551fb5b50eb2055cb7a	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	cf5365a2ebe3d33f46cadf8e454be36f27986fcf50723fea1735ffe63293626e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	d4cfd5ffe7cff44a9eeabb7576351f3b8ec1995959ea497bd053480e3c5d3acc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	de9520297afeefaf1750d52cdd2e8abea7e948cd35487a4457e75d9a122fb16d	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	f2111431a33603eb740efa422a5759ea5319bcf6a70b85234a3ff0ba65aec49f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/include/device/pci_ops.h	f21e17ed8ddd7c3ee3c25a7e51121028ff0e6e6bbc795772bbc5947319845e19	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/soc/intel/common/block/systemagent/systemagent_early.c	b36d60726fcea8a94dea418eb188fa43682e3fdbe3dd5324ea6a7290cbb6c0d5	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	postcar	src/soc/intel/common/block/systemagent/systemagent_early.c	c658d71703670ced656439daf3c760ee708779e1398646e862c1ce32b0b5a292	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/arch/x86/include/arch/pci_io_cfg.h	275198348b95cbe07edf36ac95548cd50bbefc2153891c7f33d8357d64430ffc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/arch/x86/include/arch/pci_io_cfg.h	bf04b6f9a98c062c7d542227fd0e92daae71d348fd843d4825af32d9ec194f22	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/arch/x86/include/arch/pci_io_cfg.h	cb3901c03bc032b5abe3e8ccc5aff11d7d507b8311029c8963093e5d840113ea	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	1cc217c0a7751d84561d2c36a384ac294e6cacd241e8300538ea8a56c966dc53	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	427d21c47eae29b2ce72f33ef2661079f2fb82cd0f475d5fae7e075fc990cca1	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	4b7b7c8d0dd826fc51f192bcf6ea93b10aeb83ce82893a7d1218ce66952473a8	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	5c5756cd7618036a7b647fd3f6447299d9d8f386a817ebbc7d8cec3fb357aa5c	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	5d48be351cb26d2571025f0d1db6e7bac550d720c21ba3997006acb7c4b97262	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	5fd9719e556cd33deca30a86a14c6e0eef1803e3c236dcc655aaa6e2cb59532d	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	61f6d89adc2958a3ee49940ab9c93d348f3d67b1e6d46400643db3e77d718091	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	72f2865474bbf679aa3e63c90704d8aadb8c0127ae244bb147a85a0f4952c501	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	8f7224fd6e10fc0bb0827d5f66bbdd657710697784e4c0a36426b49c7e3e0cda	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	a10eef35f4558d2c437e0d907c81ad44b4e5ea5d2333a953cb56bd9e6e79fc04	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	abdac7124cc58bd1788fcb7b7cd0a7c16f504913c9c8c38552c3eb06057af088	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	b45688afa939adc50c9de58911dfcf66f92eb6c102b7aee94fc1386a7464bf07	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	ce3a10ad28dbdded9c7ce5c93fada9574dc4d8cd0b202751cbcd0d2e007346cf	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pci_device.c	df54af44f0a4039d9bea4c6115cbd4c18c0d292a2510b447c599b096479491ce	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	0b89cbd10b4feeed68fb2da043abff72009f6028227403a49b45c6e84aaa9970	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	13eec3134c753f68fb1d6b1e84799c560ba435b923ff808c5bd57cc752e1121b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	259b556c1048c532ac6bbcb94e7944c3f8dd95cebf14e8b79c8cc2a6780fa1ff	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	2ba039c3397144831939cb46a9c392adbebf6c6c61a3d8f06addedd02157406e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	2f044de35e163475b959be1befaa151cda125560369a86c562ca94cec6fc92d8	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	311466dcfc1fb79644a204605e387f862cf0c3a8246bf2c1c88f5d08f77083ff	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	3562399e022492ca9fbf2772905a450c55247a5d4c35a3d1160d488d25ce4dea	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	3e46698815705966a9c95d7c2d9ace845c9881df44a69a8f4251e3d6c9ea3f52	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	406963495aaf2d923a81089a52c8b7a82f8e4b25c35275a2df25c5f8d2d93594	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	423da0e22b550e8f50ab57f93e7ae4fc9da96d57e94047a87a7c45d71518ca35	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	6de83c1894892afdda9a5404c8cdf842d48e88cca6e7cbe012690bbeb6654e34	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	72e97f0a4b834ca31aa55865e0145c3f53957d670200617d38da279fecaa149c	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	7db29745f941c79174cd57d942150844ed6b853a0751c640d469a65d6feb8141	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	95d7091693e03d39c66eefda6d7a4cdd71b61408c781bf12166e5ca5a750138b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	b77b80c77794a1f564fdc64b39861af95f5f90718e56bdd6f1c780cfd466008e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	cb98ced08f221bc848a0b7c036147e4db159d9bc5daeaa8431fecc3c0395e965	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	fa554d3ec1fde721b38e39e09c2b767763a4feeb9b39117a9162f5ee3aa34721	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	fb5ae6330ca95e0d503011c9b6aa9d0aec18871d5eb493162f0ee1e3980ffaa3	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pciexp_device.c	ffb46df47ab17631dff8fc9cba8c647d573826ecce712a99cd2d11bb85a48e4b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/device/pcix_device.c	80c703f279a269e1d97b8c79bc20af5eeba9ba3b64f94dcadf787d98a7fa076b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/drivers/intel/gma/opregion.c	cd4cea1e1a6c94545a665e7b0cf5a0a912ec6371965548699b7f99b26abba24f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_mmio_cfg.h	8ee08caf604fc2ef0960c075ad31c3b7a8bd2356d352d3b879559bca589a753b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_mmio_cfg.h	a654efb3fa9d95ea55e0ad7f51e05b91b42b75c5be480924f555a54bdf2ee4b6	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_mmio_cfg.h	e3003cf2cd9d460792ac31e83c6df47b01f093b0f32064e42efcac4e41cd300f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	0286eeaba27765b3df1ae9833b1074b17220067a22c49084d8738fdea2179033	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	1a391658c9e7d5955f659ad68657f7ee62eff73e18e8584ee5623b395d5a3860	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	2309570a2fe3150c6f922e0d8be09bbb28d4ae6290c277ea8d0fb1b8df43c3ec	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	2f2f796fb0bbb3dcd3973762930ca2fe0ca2d2117a037f6da360a68fefc2fdf3	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	3643f3e9542967260e94cf0102e0776d504248a6a42920c395ba98f791ec5e86	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	3a130bd6e3884467f476daa1daedb1a9cc20683cf7a61c2908144ea093fb89c6	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	45c96ade7951d80e5213cb12922856d68b62b568551b1627418d435bb4e47d58	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	4b2d1ee08dc8da861289695731ce7a7547e240776b4077aeb88269b8d1b6423d	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	50b199863d4971ecb154b83b8c4f7e3274a68d981586f73be703a8e28daabcc7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	53d78ed3d0088631f9d6e20aa606f32ea221e1bec071bb860e1596e6d36517c8	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	59264b4d1762b065125b51cb7217b4c7520a8f29d3c4a4687c51be0a78ef1dfc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	5e0071481be722b44c34b5c983416691d7b442e3d5406f5c26b8b8dc79b8923b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	5ef6bfec530e47ebdd6aba97df657abdc910bbdc4b27035964d4e3e9aa8cd465	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	5fbabf67f062fe73dffd265069c43b2b6b948c2bb15a7416a1024eed3fd524b2	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	8df85eb41902f3c828228820180d48b9074966e355b2939c6c93de03b7e53e55	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	910ac16f8e66cabfb307e8d32b8174466eb90544ad3581409bfc1b1e922e5ea2	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	97aba6b3e03ade60407018a5586a600ed33733d494d5c2d2c75fc767cfbb285e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	a5a9e31dad55dba86aebc185b5a04a03d7832195bdf55e746612b638cd638116	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	ad94dfce1c7a91db1861016457346375c0ce278de1353f7f7460a18769791df7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	b2889c0b244c02fff8cdbd98ff99f8dd640127cda2f89551fb5b50eb2055cb7a	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	b961f5a2e2a0c6edb65cb277456872388c4e74bd6fb1bbcee254ab6844b5772d	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	c8471ea595fa40c0601096846193ef9bd86fd7f7dde072a2b82febbc4a65bfd8	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	cf5365a2ebe3d33f46cadf8e454be36f27986fcf50723fea1735ffe63293626e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	d4cfd5ffe7cff44a9eeabb7576351f3b8ec1995959ea497bd053480e3c5d3acc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	de9520297afeefaf1750d52cdd2e8abea7e948cd35487a4457e75d9a122fb16d	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	f2111431a33603eb740efa422a5759ea5319bcf6a70b85234a3ff0ba65aec49f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/include/device/pci_ops.h	f21e17ed8ddd7c3ee3c25a7e51121028ff0e6e6bbc795772bbc5947319845e19	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/soc/intel/common/block/lpc/lpc_lib.c	b690951c9358f9dace55c77bc15e4994c998f69ca1566140c97c75126f1600dd	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/soc/intel/common/block/lpc/lpc_lib.c	f7d0aa29897bde0209c1a8149aeda9a2b27a80890b266dfa0e5dbcb3ba7645aa	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/soc/intel/common/block/p2sb/p2sb.c	180a8bfcf8cf0f73097f58682042b676ebf040efabf3cb191343a23f6cfd77cb	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/soc/intel/common/block/p2sb/p2sblib.c	1c9462dfbf6b5d78fe63ac8bbc928208fc0e8d66f632bcb5a69fedb8b7d26d69	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/soc/intel/common/block/systemagent/systemagent_early.c	b36d60726fcea8a94dea418eb188fa43682e3fdbe3dd5324ea6a7290cbb6c0d5	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	ramstage	src/soc/intel/common/block/systemagent/systemagent_early.c	c658d71703670ced656439daf3c760ee708779e1398646e862c1ce32b0b5a292	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/arch/x86/include/arch/pci_io_cfg.h	275198348b95cbe07edf36ac95548cd50bbefc2153891c7f33d8357d64430ffc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/arch/x86/include/arch/pci_io_cfg.h	bf04b6f9a98c062c7d542227fd0e92daae71d348fd843d4825af32d9ec194f22	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/arch/x86/include/arch/pci_io_cfg.h	cb3901c03bc032b5abe3e8ccc5aff11d7d507b8311029c8963093e5d840113ea	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_mmio_cfg.h	8ee08caf604fc2ef0960c075ad31c3b7a8bd2356d352d3b879559bca589a753b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_mmio_cfg.h	a654efb3fa9d95ea55e0ad7f51e05b91b42b75c5be480924f555a54bdf2ee4b6	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_mmio_cfg.h	e3003cf2cd9d460792ac31e83c6df47b01f093b0f32064e42efcac4e41cd300f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	0286eeaba27765b3df1ae9833b1074b17220067a22c49084d8738fdea2179033	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	1a391658c9e7d5955f659ad68657f7ee62eff73e18e8584ee5623b395d5a3860	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	2309570a2fe3150c6f922e0d8be09bbb28d4ae6290c277ea8d0fb1b8df43c3ec	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	50b199863d4971ecb154b83b8c4f7e3274a68d981586f73be703a8e28daabcc7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	59264b4d1762b065125b51cb7217b4c7520a8f29d3c4a4687c51be0a78ef1dfc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	5ef6bfec530e47ebdd6aba97df657abdc910bbdc4b27035964d4e3e9aa8cd465	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	b2889c0b244c02fff8cdbd98ff99f8dd640127cda2f89551fb5b50eb2055cb7a	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	cf5365a2ebe3d33f46cadf8e454be36f27986fcf50723fea1735ffe63293626e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	d4cfd5ffe7cff44a9eeabb7576351f3b8ec1995959ea497bd053480e3c5d3acc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	de9520297afeefaf1750d52cdd2e8abea7e948cd35487a4457e75d9a122fb16d	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	f2111431a33603eb740efa422a5759ea5319bcf6a70b85234a3ff0ba65aec49f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/include/device/pci_ops.h	f21e17ed8ddd7c3ee3c25a7e51121028ff0e6e6bbc795772bbc5947319845e19	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/soc/intel/common/block/lpc/lpc_lib.c	b690951c9358f9dace55c77bc15e4994c998f69ca1566140c97c75126f1600dd	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/soc/intel/common/block/lpc/lpc_lib.c	f7d0aa29897bde0209c1a8149aeda9a2b27a80890b266dfa0e5dbcb3ba7645aa	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/soc/intel/common/block/p2sb/p2sb.c	180a8bfcf8cf0f73097f58682042b676ebf040efabf3cb191343a23f6cfd77cb	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/soc/intel/common/block/p2sb/p2sblib.c	1c9462dfbf6b5d78fe63ac8bbc928208fc0e8d66f632bcb5a69fedb8b7d26d69	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/soc/intel/common/block/systemagent/systemagent_early.c	b36d60726fcea8a94dea418eb188fa43682e3fdbe3dd5324ea6a7290cbb6c0d5	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	romstage	src/soc/intel/common/block/systemagent/systemagent_early.c	c658d71703670ced656439daf3c760ee708779e1398646e862c1ce32b0b5a292	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/arch/x86/include/arch/pci_io_cfg.h	275198348b95cbe07edf36ac95548cd50bbefc2153891c7f33d8357d64430ffc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/arch/x86/include/arch/pci_io_cfg.h	bf04b6f9a98c062c7d542227fd0e92daae71d348fd843d4825af32d9ec194f22	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/arch/x86/include/arch/pci_io_cfg.h	cb3901c03bc032b5abe3e8ccc5aff11d7d507b8311029c8963093e5d840113ea	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_mmio_cfg.h	8ee08caf604fc2ef0960c075ad31c3b7a8bd2356d352d3b879559bca589a753b	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_mmio_cfg.h	a654efb3fa9d95ea55e0ad7f51e05b91b42b75c5be480924f555a54bdf2ee4b6	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_mmio_cfg.h	e3003cf2cd9d460792ac31e83c6df47b01f093b0f32064e42efcac4e41cd300f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	0286eeaba27765b3df1ae9833b1074b17220067a22c49084d8738fdea2179033	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	1a391658c9e7d5955f659ad68657f7ee62eff73e18e8584ee5623b395d5a3860	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	2309570a2fe3150c6f922e0d8be09bbb28d4ae6290c277ea8d0fb1b8df43c3ec	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	50b199863d4971ecb154b83b8c4f7e3274a68d981586f73be703a8e28daabcc7	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	59264b4d1762b065125b51cb7217b4c7520a8f29d3c4a4687c51be0a78ef1dfc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	5ef6bfec530e47ebdd6aba97df657abdc910bbdc4b27035964d4e3e9aa8cd465	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	b2889c0b244c02fff8cdbd98ff99f8dd640127cda2f89551fb5b50eb2055cb7a	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	cf5365a2ebe3d33f46cadf8e454be36f27986fcf50723fea1735ffe63293626e	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	d4cfd5ffe7cff44a9eeabb7576351f3b8ec1995959ea497bd053480e3c5d3acc	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	de9520297afeefaf1750d52cdd2e8abea7e948cd35487a4457e75d9a122fb16d	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	f2111431a33603eb740efa422a5759ea5319bcf6a70b85234a3ff0ba65aec49f	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/include/device/pci_ops.h	f21e17ed8ddd7c3ee3c25a7e51121028ff0e6e6bbc795772bbc5947319845e19	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/security/tcg/opal_s3/opal_nvme.c	8a98158f29c706158de5beead5c2387d2f43d000f770e21b0432f703bcc4d294	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/soc/intel/common/block/p2sb/p2sb.c	180a8bfcf8cf0f73097f58682042b676ebf040efabf3cb191343a23f6cfd77cb	reviewed stage-specific preprocessor expansion
+expanded	unknown	coreboot	unknown-overlap	smm	src/soc/intel/common/block/p2sb/p2sblib.c	1c9462dfbf6b5d78fe63ac8bbc928208fc0e8d66f632bcb5a69fedb8b7d26d69	reviewed stage-specific preprocessor expansion

--- a/payload/cdk2-nvme-ownership.md
+++ b/payload/cdk2-nvme-ownership.md
@@ -1,0 +1,43 @@
+# CDK2 NVMe bus-master evidence
+
+This is external evidence, not part of the coreboot ownership gate. It must
+remain unresolved until coreboot CI checks out the pinned CDK2 revision and
+runs the named tests. In particular, this document is not sufficient evidence
+to disable `PCI_ALLOW_BUS_MASTER_ANY_DEVICE`.
+
+Reviewed CDK2 commit:
+
+`b4492d5cb26847b628cdf8c4252a4331359ea385`
+
+Pinned Git object IDs:
+
+- `src/modules/nvme/pci_adapter.c`: `5196febae81adeda7a8a98739b5ca643caa87511`
+- `tests/nvme_entry_test.c`: `0a1fe3a47955ef6989efd25bf0c34cefd5a6ce5a`
+- `tests/linear_boot_test.c`: `c2b3e8ff2cc4489b4903e21bd6ded852d6d7b0aa`
+
+At that revision, `cdk2_nvme_pci_adapter_init()` reads the original PCI
+attributes before enabling the selected NVMe controller. Its release path
+disables the attributes it acquired and restores the saved attribute value.
+That is payload endpoint ownership; it does not establish ownership of the PCIe
+bridge forwarding path.
+
+Locally observed on 2026-08-25:
+
+```text
+$ make native-nvme-test
+nvme model tests: PASS
+nvme controller tests: PASS
+nvme binding tests: PASS
+nvme pass thru tests: PASS
+nvme block tests: PASS
+nvme entry tests: PASS
+nvme PCI transaction tests: PASS
+nvme diagnostic tests: PASS
+
+$ make native-linear-boot-test
+cdk2 linear boot test: PASS
+```
+
+These local results are recorded for review only. A future policy-changing
+patch must add paired CI that verifies the exact commit, object IDs and test
+results. No comparison with Depthcharge is asserted here.

--- a/util/audit-starbook-mtl-pci-busmaster.sh
+++ b/util/audit-starbook-mtl-pci-busmaster.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmp_base=${TMPDIR:-/tmp}
+tmp=$(mktemp -d "$tmp_base/cb-busmaster-audit.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+awk '!/^CONFIG_ANY_TOOLCHAIN=/' "$root/configs/config.starlabs_starbook_mtl" \
+	> "$tmp/defconfig"
+printf 'CONFIG_ANY_TOOLCHAIN=y\n' >> "$tmp/defconfig"
+
+mkdir -p "$tmp/build"
+if [ -f "$root/build/xcompile" ]; then
+	cp "$root/build/xcompile" "$tmp/build/xcompile"
+fi
+
+make -s -C "$root" TMPDIR="$tmp" DOTCONFIG="$tmp/config" obj="$tmp/build" \
+	KBUILD_DEFCONFIG="$tmp/defconfig" defconfig 2> "$tmp/defconfig.err"
+make -s -C "$root" TMPDIR="$tmp" DOTCONFIG="$tmp/config" obj="$tmp/build" \
+	CC_x86_32="${CC:-gcc}" IASL="${IASL:-iasl}" printall \
+	> "$tmp/printall" 2> "$tmp/printall.err"
+make -s -C "$root" TMPDIR="$tmp" DOTCONFIG="$tmp/config" obj="$tmp/build" \
+	CC_x86_32="${CC:-gcc}" IASL="${IASL:-iasl}" \
+	print-pci-busmaster-build-graph > "$tmp/build-graph" 2>> "$tmp/printall.err"
+
+cat "$tmp/defconfig.err" "$tmp/printall.err" >&2
+if grep -Eq 'No space left|write error' "$tmp/defconfig.err" "$tmp/printall.err"; then
+	echo "failed to resolve the enabled-source graph" >&2
+	exit 1
+fi
+
+awk '/^allsrcs:/{enabled=1; next} enabled && NF == 0 {exit} \
+	enabled && /^(src|payloads)\// {print}' \
+	"$tmp/printall" | sort -u > "$tmp/enabled-sources"
+
+cat > "$tmp/cc-audit" <<EOF
+#!/bin/sh
+exec ${CC:-gcc} -save-temps=obj "\$@"
+EOF
+chmod +x "$tmp/cc-audit"
+has_verstage=$(grep -c '^CONFIG_VBOOT_SEPARATE_VERSTAGE=y$' "$tmp/config" || true)
+awk -F '\t' -v has_verstage="$has_verstage" \
+	'$1 ~ /^(bootblock|romstage|postcar|ramstage|smm|verstage)$/ &&
+	($1 != "verstage" || has_verstage) &&
+	$2 ~ /^(src|3rdparty|payloads)\// && $2 ~ /\.c$/ && $3 ~ /\.o$/ { print $3 }' \
+	"$tmp/build-graph" | sort -u > "$tmp/audit-objects"
+# Compile translation units without linking the firmware or building its
+# payload. Besides proving membership, -save-temps=obj captures the exact
+# preprocessor expansion and the compiler-generated dependency closure.
+if ! xargs make -s -C "$root" -j4 TMPDIR="$tmp" DOTCONFIG="$tmp/config" \
+	obj="$tmp/build" CC_x86_32="$tmp/cc-audit" IASL="${IASL:-iasl}" \
+	< "$tmp/audit-objects" > "$tmp/compile.out" 2> "$tmp/compile.err"; then
+	cat "$tmp/compile.out" "$tmp/compile.err" >&2
+	exit 1
+fi
+awk -F '\t' -v has_verstage="$has_verstage" \
+	'$1 ~ /^(bootblock|romstage|postcar|ramstage|smm|verstage)$/ &&
+	($1 != "verstage" || has_verstage) &&
+	$2 ~ /^(src|3rdparty|payloads)\// && $2 ~ /\.c$/ && $3 ~ /\.o$/ {
+		unit = $3; sub(/\.o$/, ".i", unit); print $1 "\t" unit
+	}' \
+	"$tmp/build-graph" | sort -u > "$tmp/preprocessed"
+[ -s "$tmp/preprocessed" ] || {
+	echo "no preprocessed translation units were generated" >&2
+	exit 1
+}
+devicetree="$tmp/build/mainboard/starlabs/starbook/static.c"
+[ -f "$devicetree" ] || {
+	echo "generated devicetree is missing" >&2
+	exit 1
+}
+
+"$root/util/check-pci-busmaster-ownership.sh" \
+	"$root/configs/policies/starlabs_starbook_mtl_busmaster_ownership.tsv" \
+	"$root" "$tmp/config" "$tmp/enabled-sources" "$tmp/preprocessed" \
+	"$devicetree"

--- a/util/check-pci-busmaster-ownership-test.sh
+++ b/util/check-pci-busmaster-ownership-test.sh
@@ -1,0 +1,549 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+checker=$root/util/check-pci-busmaster-ownership.sh
+tmp_base=${TMPDIR:-/tmp}
+tmp=$(mktemp -d "$tmp_base/cb-busmaster-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+tab=$(printf '\t')
+
+"$root/util/audit-starbook-mtl-pci-busmaster.sh"
+
+expect_failure()
+{
+	name=$1
+	shift
+	if "$@" > "$tmp/$name.out" 2>&1; then
+		echo "mutation unexpectedly passed: $name" >&2
+		exit 1
+	fi
+	case "$name" in
+wrong_state|wrong_owner|wrong_stage|stage_removed|numeric_direct|config8_command|\
+overlap16_at3|overlap32_at1|overlap32_at2|overlap32_at3|overlap32_at4|\
+overlap_byte5|offset_sum|command_plus_zero|enum_offset|variable_offset|\
+same_line_offset|header_helper|generated_include|disable_helper|inline_helper_body|\
+macro_helper|return_helper|comma_helper|ternary_helper|cast_helper|paren_helper|\
+update_disable|shift_20|\
+write_zero|write_clear|write_enable|write_unknown|write_overlap_clear|\
+write_offset_unknown)
+		expected='preprocessed PCI command mutation inventory drift' ;;
+	wrong_site_state|wrong_site_owner|wrong_site_class)
+		expected='PCI bus-master site inventory drift' ;;
+	wrong_class) expected='malformed expanded row' ;;
+	config_branch) expected='resolved config drift' ;;
+	path_escape) expected='unsafe source path' ;;
+	stale) expected='stale enabled source|manifest source is not in resolved build graph' ;;
+	duplicate) expected='duplicate site row' ;;
+	prose_evidence|missing|comment|new_site|callback_missing|raw_disable_helper|\
+	raw_inline_helper_body|raw_macro_helper|raw_split_line_helper|\
+	raw_return_helper|raw_comma_helper|raw_ternary_helper|raw_cast_helper|raw_paren_helper)
+		expected='PCI bus-master site inventory drift' ;;
+	stale_preprocessed) expected='stale preprocessed unit' ;;
+	devicetree_drift) expected='generated devicetree drift' ;;
+	*) echo "mutation has no diagnostic expectation: $name" >&2; exit 1 ;;
+	esac
+	grep -Eq "$expected" "$tmp/$name.out" || {
+		echo "mutation failed for the wrong reason: $name" >&2
+		cat "$tmp/$name.out" >&2
+		exit 1
+	}
+}
+
+mkdir -p "$tmp/tree/src"
+cat > "$tmp/tree/src/owner.c" <<'EOF'
+void enable_owner(void)
+{
+	pci_or_config16(dev, PCI_COMMAND, PCI_COMMAND_MASTER);
+}
+EOF
+cat > "$tmp/config" <<'EOF'
+CONFIG_PCI_ALLOW_BUS_MASTER_ANY_DEVICE=y
+CONFIG_PCI_SET_BUS_MASTER_PCI_BRIDGES=y
+CONFIG_PAYLOAD_OWNS_PCI_DEVICES=y
+CONFIG_RUN_FSP_GOP=y
+# CONFIG_NO_GFX_INIT is not set
+CONFIG_TCG_OPAL_S3_UNLOCK=y
+# CONFIG_CONSOLE_SERIAL is not set
+EOF
+printf 'src/owner.c\n' > "$tmp/sources"
+cat > "$tmp/owner.i" <<EOF
+# 1 "$tmp/tree/src/owner.c"
+void enable_owner(void)
+{
+ pci_or_config16(dev, 4, (1 << 2));
+}
+EOF
+printf 'ramstage\t%s\n' "$tmp/owner.i" > "$tmp/preprocessed-list"
+printf '%s\n' 'generated static devicetree fixture' > "$tmp/static.c"
+
+context='void enable_owner(void) { pci_or_config16(dev, PCI_COMMAND, PCI_COMMAND_MASTER); }'
+digest=$(printf '%s\n%s\n' src/owner.c "$context" | sha256sum | awk '{print $1}')
+expanded_statement='void enable_owner(void) { pci_or_config16(dev, 4, (1 << 2));'
+expanded_digest=$(printf '%s:%s\n%s\n' src/owner.c 1 "$expanded_statement" |
+	sha256sum | awk '{print $1}')
+devicetree_digest=$(sha256sum "$tmp/static.c" | awk '{print $1}')
+cat > "$tmp/manifest" <<EOF
+# SPDX-License-Identifier: GPL-2.0-only
+devicetree${tab}${devicetree_digest}${tab}generated devicetree fixture
+config${tab}CONFIG_PCI_ALLOW_BUS_MASTER_ANY_DEVICE${tab}y${tab}fixture
+config${tab}CONFIG_PCI_SET_BUS_MASTER_PCI_BRIDGES${tab}y${tab}fixture
+config${tab}CONFIG_PAYLOAD_OWNS_PCI_DEVICES${tab}y${tab}fixture
+config${tab}CONFIG_RUN_FSP_GOP${tab}y${tab}fixture
+config${tab}CONFIG_NO_GFX_INIT${tab}n${tab}fixture
+config${tab}CONFIG_TCG_OPAL_S3_UNLOCK${tab}y${tab}fixture
+config${tab}CONFIG_CONSOLE_SERIAL${tab}n${tab}fixture
+site${tab}enable${tab}coreboot${tab}fixture${tab}src/owner.c${tab}${digest}${tab}fixture owner
+expanded${tab}enable${tab}coreboot${tab}command-register${tab}ramstage${tab}src/owner.c${tab}${expanded_digest}${tab}fixture expansion
+EOF
+
+check_fixture()
+{
+	"$checker" "$@" "$tmp/tree" "$tmp/config" "$tmp/sources" \
+		"$tmp/preprocessed-list" "$tmp/static.c"
+}
+
+check_fixture "$tmp/manifest"
+
+# Helper declarations and definition signatures describe types/ownership but
+# execute no PCI mutation. Calls in ordinary bodies, inline bodies, and macro
+# expansions remain part of both inventories.
+cp "$tmp/owner.i" "$tmp/declaration-base.i"
+cat >> "$tmp/owner.i" <<'EOF'
+void pci_dev_disable_bus_master(struct device *dev);
+void pci_dev_request_bus_master(struct device *dev);
+void pci_dev_disable_bus_master(struct device *dev) { }
+EOF
+check_fixture "$tmp/manifest" > /dev/null
+cp "$tmp/declaration-base.i" "$tmp/owner.i"
+cat > "$tmp/tree/src/declarations.c" <<'EOF'
+void pci_dev_disable_bus_master(struct device *dev);
+void pci_dev_request_bus_master(struct device *dev);
+void pci_dev_disable_bus_master(struct device *dev) { }
+void
+pci_dev_request_bus_master(struct device *dev);
+extern void pci_dev_request_bus_master
+/* The opening parenthesis may begin after comment-only lines. */
+(struct device *dev);
+static void
+pci_dev_disable_bus_master
+/* Likewise for a multiline definition signature. */
+(
+	struct device *dev
+)
+{
+}
+EOF
+printf 'src/owner.c\nsrc/declarations.c\n' > "$tmp/sources"
+check_fixture "$tmp/manifest" > /dev/null
+printf 'src/owner.c\n' > "$tmp/sources"
+
+sed '/^site/ s/enable/disable/' "$tmp/manifest" > "$tmp/wrong-site-state"
+expect_failure wrong_site_state check_fixture "$tmp/wrong-site-state"
+sed '/^site/ s/coreboot/payload/' "$tmp/manifest" > "$tmp/wrong-site-owner"
+expect_failure wrong_site_owner check_fixture "$tmp/wrong-site-owner"
+sed '/^site/ s/fixture/other-class/' "$tmp/manifest" > "$tmp/wrong-site-class"
+expect_failure wrong_site_class check_fixture "$tmp/wrong-site-class"
+
+sed '/^expanded/ s/enable/disable/' "$tmp/manifest" \
+	> "$tmp/wrong-state"
+expect_failure wrong_state check_fixture "$tmp/wrong-state"
+sed '/^expanded/ s/coreboot/payload/' "$tmp/manifest" \
+	> "$tmp/wrong-owner"
+expect_failure wrong_owner check_fixture "$tmp/wrong-owner"
+sed '/^expanded/ s/ramstage/romstage/' "$tmp/manifest" > "$tmp/wrong-stage"
+expect_failure wrong_stage check_fixture "$tmp/wrong-stage"
+cp "$tmp/manifest" "$tmp/multistage-manifest"
+sed -n '/^expanded/ s/ramstage/verstage/p' "$tmp/manifest" \
+	>> "$tmp/multistage-manifest"
+printf 'ramstage\t%s\nverstage\t%s\n' "$tmp/owner.i" "$tmp/owner.i" \
+	> "$tmp/preprocessed-list"
+check_fixture "$tmp/multistage-manifest"
+printf 'ramstage\t%s\n' "$tmp/owner.i" > "$tmp/preprocessed-list"
+expect_failure stage_removed check_fixture "$tmp/multistage-manifest"
+sed '/^expanded/ s/command-register/endpoint/' \
+	"$tmp/manifest" > "$tmp/wrong-class"
+expect_failure wrong_class check_fixture "$tmp/wrong-class"
+
+cp "$tmp/owner.i" "$tmp/original-owner.i"
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config16(dev, 0x04, 0x4);
+EOF
+expect_failure numeric_direct check_fixture "$tmp/manifest"
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config16(dev, 4, 0);
+EOF
+expect_failure write_zero check_fixture "$tmp/manifest"
+grep -q '^+disable.*command-register' "$tmp/write_zero.out" || {
+	echo "constant zero write was not classified as disable" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config16(dev, 4, 0x1);
+EOF
+expect_failure write_clear check_fixture "$tmp/manifest"
+grep -q '^+disable.*command-register' "$tmp/write_clear.out" || {
+	echo "constant write clearing BME was not classified as disable" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config16(dev, 4, 0x4);
+EOF
+expect_failure write_enable check_fixture "$tmp/manifest"
+grep -q '^+enable.*command-register' "$tmp/write_enable.out" || {
+	echo "constant write setting BME was not classified as enable" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config16(dev, 4, value);
+EOF
+expect_failure write_unknown check_fixture "$tmp/manifest"
+grep -q '^+unknown.*command-register' "$tmp/write_unknown.out" || {
+	echo "unknown write value was not classified conservatively" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config32(dev, 3, 0x1);
+EOF
+expect_failure write_overlap_clear check_fixture "$tmp/manifest"
+grep -q '^+disable.*command-overlap' "$tmp/write_overlap_clear.out" || {
+	echo "mixed-width constant clear was not classified as disable" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config16(dev, offset, 0);
+EOF
+expect_failure write_offset_unknown check_fixture "$tmp/manifest"
+grep -q '^+unknown.*unknown-overlap' "$tmp/write_offset_unknown.out" || {
+	echo "unknown write offset was not classified conservatively" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+# A constant write outside command-register bytes is not a BME mutation.
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config16(dev, 6, 0);
+EOF
+check_fixture "$tmp/manifest" > /dev/null
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_update_config16(dev, 4, ~(1U << 2), 0);
+EOF
+expect_failure update_disable check_fixture "$tmp/manifest"
+grep -q '^+disable.*command-register' "$tmp/update_disable.out" || {
+	echo "update mask clearing BME was not classified as disable" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_or_config32(dev, 4, (1U << 20));
+EOF
+expect_failure shift_20 check_fixture "$tmp/manifest"
+grep -q '^+unknown.*command-register' "$tmp/shift_20.out" || {
+	echo "shift count 20 was confused with BME bit 2" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_dev_disable_bus_master(dev);
+EOF
+expect_failure disable_helper check_fixture "$tmp/manifest"
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+static inline void disable_inline(void) { pci_dev_disable_bus_master(dev); }
+EOF
+expect_failure inline_helper_body check_fixture "$tmp/manifest"
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_dev_disable_bus_master(dev);
+EOF
+expect_failure macro_helper check_fixture "$tmp/manifest"
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+for mutation in return comma ternary cast paren; do
+	cp "$tmp/original-owner.i" "$tmp/owner.i"
+	case "$mutation" in
+	return) printf '%s\n' 'void f(void) { return pci_dev_disable_bus_master(dev); }' >> "$tmp/owner.i" ;;
+	comma) printf '%s\n' 'void f(void) { (prepare(), pci_dev_disable_bus_master(dev)); }' >> "$tmp/owner.i" ;;
+	ternary) printf '%s\n' 'void f(void) { ready ? pci_dev_disable_bus_master(dev) : (void)0; }' >> "$tmp/owner.i" ;;
+	cast) printf '%s\n' 'void f(void) { (void)pci_dev_disable_bus_master(dev); }' >> "$tmp/owner.i" ;;
+	paren) printf '%s\n' 'void f(void) { (pci_dev_disable_bus_master(dev)); }' >> "$tmp/owner.i" ;;
+	esac
+	expect_failure "${mutation}_helper" check_fixture "$tmp/manifest"
+done
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/tree/src/owner.c" <<'EOF'
+void disable_owner(void) { pci_dev_disable_bus_master(dev); }
+EOF
+expect_failure raw_disable_helper check_fixture "$tmp/manifest"
+sed -i '$d' "$tmp/tree/src/owner.c"
+
+cat >> "$tmp/tree/src/owner.c" <<'EOF'
+static inline void disable_inline(void) { pci_dev_disable_bus_master(dev); }
+EOF
+expect_failure raw_inline_helper_body check_fixture "$tmp/manifest"
+sed -i '$d' "$tmp/tree/src/owner.c"
+
+# A helper stored as a callback is an ownership site even though there is no
+# call expression at the point of assignment.
+cp "$tmp/tree/src/owner.c" "$tmp/callback-owner-base.c"
+cat > "$tmp/tree/src/owner.c" <<'EOF'
+static struct device_operations callback_ops = {
+	.final =
+		pci_dev_request_bus_master,
+};
+EOF
+expect_failure callback_missing check_fixture "$tmp/manifest"
+grep -q '^+enable.*src/owner.c' "$tmp/callback_missing.out" || {
+	echo "callback site was not reported in the raw inventory" >&2; exit 1;
+}
+cp "$tmp/callback-owner-base.c" "$tmp/tree/src/owner.c"
+
+# A line break before the call parenthesis does not turn an invocation into a
+# declaration. It remains an executable ownership site.
+cat >> "$tmp/tree/src/owner.c" <<'EOF'
+void split_line_call(void)
+{
+	pci_dev_disable_bus_master
+		(dev);
+}
+EOF
+expect_failure raw_split_line_helper check_fixture "$tmp/manifest"
+grep -q '^+disable.*src/owner.c' "$tmp/raw_split_line_helper.out" || {
+	echo "split-line helper call was not reported in the raw inventory" >&2
+	exit 1
+}
+cp "$tmp/callback-owner-base.c" "$tmp/tree/src/owner.c"
+
+# Tokens in comments, strings, and character literals are not executable
+# ownership sites and must not perturb the inventory.
+cp "$tmp/tree/src/owner.c" "$tmp/comment-token-owner-base.c"
+cat > "$tmp/tree/src/owner.c" <<'EOF'
+/* pci_dev_request_bus_master and
+ * pci_dev_disable_bus_master(dev)
+ */
+static const char *helper_name = "pci_dev_request_bus_master";
+static const int helper_initial = 'p'; // pci_dev_disable_bus_master(dev)
+EOF
+awk '$1 != "site"' "$tmp/manifest" > "$tmp/comment-token-manifest"
+check_fixture "$tmp/comment-token-manifest" > /dev/null
+cp "$tmp/comment-token-owner-base.c" "$tmp/tree/src/owner.c"
+
+cat >> "$tmp/tree/src/owner.c" <<'EOF'
+/* adjacent pci_dev_request_bus_master prose */
+static const char *adjacent_text = "first pci_dev_disable_bus_master text";
+EOF
+check_fixture "$tmp/manifest" > /dev/null
+sed -i 's/adjacent pci_dev_request_bus_master prose/unrelated changed comment/' \
+	"$tmp/tree/src/owner.c"
+sed -i 's/first pci_dev_disable_bus_master text/completely changed string/' \
+	"$tmp/tree/src/owner.c"
+check_fixture "$tmp/manifest" > /dev/null
+cp "$tmp/comment-token-owner-base.c" "$tmp/tree/src/owner.c"
+
+cat >> "$tmp/tree/src/owner.c" <<'EOF'
+#define DISABLE_OWNER(dev) pci_dev_disable_bus_master(dev)
+EOF
+expect_failure raw_macro_helper check_fixture "$tmp/manifest"
+sed -i '$d' "$tmp/tree/src/owner.c"
+
+for mutation in return comma ternary cast paren; do
+	case "$mutation" in
+	return) line='void f(void) { return pci_dev_disable_bus_master(dev); }' ;;
+	comma) line='void f(void) { (prepare(), pci_dev_disable_bus_master(dev)); }' ;;
+	ternary) line='void f(void) { ready ? pci_dev_disable_bus_master(dev) : (void)0; }' ;;
+	cast) line='void f(void) { (void)pci_dev_disable_bus_master(dev); }' ;;
+	paren) line='void f(void) { (pci_dev_disable_bus_master(dev)); }' ;;
+	esac
+	printf '%s\n' "$line" >> "$tmp/tree/src/owner.c"
+	expect_failure "raw_${mutation}_helper" check_fixture "$tmp/manifest"
+	sed -i '$d' "$tmp/tree/src/owner.c"
+done
+
+printf 'ramstage\t%s\nramstage\t%s/missing.i\n' "$tmp/owner.i" "$tmp" \
+	> "$tmp/preprocessed-list"
+expect_failure stale_preprocessed check_fixture "$tmp/manifest"
+printf 'ramstage\t%s\n' "$tmp/owner.i" > "$tmp/preprocessed-list"
+
+printf '%s\n' 'mutated generated static devicetree' > "$tmp/static.c"
+expect_failure devicetree_drift check_fixture "$tmp/manifest"
+printf '%s\n' 'generated static devicetree fixture' > "$tmp/static.c"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_or_config8(dev, 4, (1U << 2));
+EOF
+expect_failure config8_command check_fixture "$tmp/manifest"
+if grep -q command-overlap "$tmp/config8_command.out"; then
+	echo "config8 at command start was misclassified" >&2; exit 1
+fi
+grep -q '^+enable.*command-register' "$tmp/config8_command.out" || {
+	echo "config8 BME bit was not derived" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+for mutation in 'overlap16_at3:16:3:10' 'overlap32_at1:32:1:26' \
+	'overlap32_at2:32:2:18' 'overlap32_at3:32:3:10' \
+	'overlap32_at4:32:4:2'; do
+	name=${mutation%%:*}
+	rest=${mutation#*:}; width=${rest%%:*}
+	rest=${rest#*:}; offset=${rest%%:*}; bit=${rest##*:}
+	printf 'pci_or_config%s(dev, %s, (1U << %s));\n' "$width" "$offset" "$bit" \
+		>> "$tmp/owner.i"
+	expect_failure "$name" check_fixture "$tmp/manifest"
+	if [ "$offset" -ne 4 ]; then
+		grep -q '^+enable.*command-overlap' "$tmp/$name.out" || {
+			echo "unaligned access was not classified as overlap: $name" >&2; exit 1;
+		}
+	else
+		grep -q '^+enable.*command-register' "$tmp/$name.out" || {
+			echo "aligned dword BME bit was not derived" >&2; exit 1;
+		}
+	fi
+	cp "$tmp/original-owner.i" "$tmp/owner.i"
+done
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config8(dev, 5, 0xff);
+EOF
+expect_failure overlap_byte5 check_fixture "$tmp/manifest"
+grep -q '^+unknown.*command-overlap' "$tmp/overlap_byte5.out" || {
+	echo "byte 5 access was not classified as command overlap" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+# These byte ranges are statically disjoint from command bytes 4-5.
+cat >> "$tmp/owner.i" <<'EOF'
+pci_or_config8(dev, 3, 0xff);
+pci_or_config8(dev, 6, 0xff);
+pci_or_config16(dev, 2, 0xffff);
+pci_or_config16(dev, 6, 0xffff);
+pci_or_config32(dev, 0, 0xffffffff);
+pci_or_config32(dev, 6, 0xffffffff);
+EOF
+check_fixture "$tmp/manifest" > /dev/null
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_or_config16(dev, (2 + 2), (1U << 2));
+EOF
+expect_failure offset_sum check_fixture "$tmp/manifest"
+if grep -q unknown-overlap "$tmp/offset_sum.out"; then
+	echo "constant offset sum was not folded" >&2; exit 1
+fi
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_or_config16(dev, (4 + 0), 0x4);
+EOF
+expect_failure command_plus_zero check_fixture "$tmp/manifest"
+if grep -q unknown-overlap "$tmp/command_plus_zero.out"; then
+	echo "PCI_COMMAND plus zero was not folded" >&2; exit 1
+fi
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+enum { enum_offset = 2 + 2 };
+pci_or_config16(dev, enum_offset, 0x4);
+EOF
+expect_failure enum_offset check_fixture "$tmp/manifest"
+if grep -q unknown-overlap "$tmp/enum_offset.out"; then
+	echo "enum offset was not folded" >&2; exit 1
+fi
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_write_config16(dev, offset, 0x4);
+EOF
+expect_failure variable_offset check_fixture "$tmp/manifest"
+grep -q unknown-overlap "$tmp/variable_offset.out" || {
+	echo "variable offset was not classified conservatively" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<'EOF'
+pci_or_config16(dev, 6, 0x4); pci_write_config16(dev, offset, 0x4);
+EOF
+expect_failure same_line_offset check_fixture "$tmp/manifest"
+grep -q unknown-overlap "$tmp/same_line_offset.out" || {
+	echo "second same-line offset escaped classification" >&2; exit 1;
+}
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+# A statically non-command register does not enter the BME inventory.
+cat >> "$tmp/owner.i" <<'EOF'
+pci_or_config16(dev, 6, 0x4);
+EOF
+check_fixture "$tmp/manifest" > /dev/null
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<EOF
+# 1 "$tmp/tree/src/helper.h"
+static inline void helper(void) { pci_or_config16(dev, 4, (1U << 2)); }
+# 9 "$tmp/tree/src/owner.c"
+helper();
+EOF
+expect_failure header_helper check_fixture "$tmp/manifest"
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+cat >> "$tmp/owner.i" <<EOF
+# 1 "$tmp/build/generated-bme.h"
+pci_update_config16(dev, 4, ~0, (1 << 2));
+EOF
+expect_failure generated_include check_fixture "$tmp/manifest"
+cp "$tmp/original-owner.i" "$tmp/owner.i"
+
+awk '$1 != "site"' "$tmp/manifest" > "$tmp/missing"
+expect_failure missing check_fixture "$tmp/missing"
+
+cp "$tmp/manifest" "$tmp/duplicate"
+grep '^site' "$tmp/manifest" >> "$tmp/duplicate"
+expect_failure duplicate check_fixture "$tmp/duplicate"
+
+sed 's#src/owner.c#src/missing.c#' "$tmp/manifest" > "$tmp/stale"
+expect_failure stale check_fixture "$tmp/stale"
+
+awk '$1 != "site"' "$tmp/manifest" > "$tmp/comment"
+printf '# site%s' "$tab" >> "$tmp/comment"
+grep '^site' "$tmp/manifest" | cut -f2- >> "$tmp/comment"
+expect_failure comment check_fixture "$tmp/comment"
+
+sed 's#src/owner.c#../owner.c#' "$tmp/manifest" > "$tmp/escape"
+expect_failure path_escape check_fixture "$tmp/escape"
+
+sed 's/CONFIG_PAYLOAD_OWNS_PCI_DEVICES=y/# CONFIG_PAYLOAD_OWNS_PCI_DEVICES is not set/' \
+	"$tmp/config" > "$tmp/config-drift"
+expect_failure config_branch "$checker" "$tmp/manifest" "$tmp/tree" \
+	"$tmp/config-drift" "$tmp/sources" "$tmp/preprocessed-list" "$tmp/static.c"
+
+cp "$tmp/tree/src/owner.c" "$tmp/original-owner.c"
+cat >> "$tmp/tree/src/owner.c" <<'EOF'
+void new_owner(void)
+{
+	pci_or_config16(other, PCI_COMMAND, PCI_COMMAND_MASTER);
+}
+EOF
+expect_failure new_site check_fixture "$tmp/manifest"
+cp "$tmp/original-owner.c" "$tmp/tree/src/owner.c"
+
+sed 's/pci_or_config16/\/\/ pci_or_config16/' "$tmp/tree/src/owner.c" \
+	> "$tmp/comment-owner.c"
+cp "$tmp/comment-owner.c" "$tmp/tree/src/owner.c"
+expect_failure prose_evidence check_fixture "$tmp/manifest"
+
+grep -q 'b4492d5cb26847b628cdf8c4252a4331359ea385' \
+	"$root/payload/cdk2-nvme-ownership.md"
+grep -q 'external evidence, not part of the coreboot ownership gate' \
+	"$root/payload/cdk2-nvme-ownership.md"
+
+echo "PCI bus-master ownership mutation tests passed"

--- a/util/check-pci-busmaster-ownership.sh
+++ b/util/check-pci-busmaster-ownership.sh
@@ -1,0 +1,567 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+usage()
+{
+	echo "usage: $0 <manifest> <coreboot-tree> <resolved-config> <enabled-sources> <preprocessed-list> <generated-devicetree>" >&2
+	exit 2
+}
+
+[ "$#" -eq 6 ] || usage
+manifest=$1
+tree=$2
+config=$3
+sources=$4
+preprocessed=$5
+devicetree=$6
+
+for input in "$manifest" "$config" "$sources" "$preprocessed" "$devicetree"; do
+	[ -f "$input" ] || { echo "missing audit input: $input" >&2; exit 1; }
+done
+
+case "$tree" in
+	/*) ;;
+	*) echo "coreboot tree must be absolute" >&2; exit 1 ;;
+esac
+
+tmp_base=${TMPDIR:-/tmp}
+tmp=$(mktemp -d "$tmp_base/cb-busmaster-check.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+: > "$tmp/expected-config"
+: > "$tmp/expected-sites"
+: > "$tmp/expected-expanded"
+: > "$tmp/expected-devicetree"
+: > "$tmp/manifest-sources"
+
+awk -F '\t' '
+/^[[:space:]]*#/ || NF == 0 { next }
+$1 == "config" {
+	if (NF != 4 || $2 !~ /^CONFIG_[A-Z0-9_]+$/ || $3 !~ /^(y|n)$/ || $4 == "")
+		bad("malformed config row", NR)
+	if (configs[$2]++) bad("duplicate config row", NR)
+	print $2 "\t" $3 > config_out
+	next
+}
+$1 == "site" {
+	if (NF != 7 || $2 !~ /^(enable|disable|dormant|capability)$/ ||
+	    $3 !~ /^(coreboot|payload)$/ || $4 == "" || $5 == "" ||
+	    $6 !~ /^[0-9a-f]{64}$/ || $7 == "")
+		bad("malformed site row", NR)
+	if ($5 ~ /^\// || $5 ~ /(^|\/)\.\.($|\/)/)
+		bad("unsafe source path", NR)
+	key = $2 "\t" $3 "\t" $4 "\t" $5 "\t" $6
+	if (sites[key]++) bad("duplicate site row", NR)
+	print key > site_out
+	print $5 > source_out
+	next
+}
+$1 == "expanded" {
+	if (NF != 8 || $2 !~ /^(enable|disable|dormant|unknown)$/ ||
+	    $3 !~ /^(coreboot|payload)$/ ||
+	    $4 !~ /^(command-register|command-overlap|unknown-overlap)$/ ||
+	    $5 !~ /^(bootblock|romstage|postcar|ramstage|smm|verstage)$/ ||
+	    $6 == "" || $7 !~ /^[0-9a-f]{64}$/ || $8 == "")
+		bad("malformed expanded row", NR)
+	if ($6 ~ /^\// || $6 ~ /(^|\/)\.\.($|\/)/)
+		bad("unsafe expanded source path", NR)
+	key = $2 "\t" $3 "\t" $4 "\t" $5 "\t" $6 "\t" $7
+	if (expanded[key]++) bad("duplicate expanded row", NR)
+	print key > expanded_out
+	next
+}
+$1 == "devicetree" {
+	if (NF != 3 || $2 !~ /^[0-9a-f]{64}$/ || $3 == "" || devicetree_seen++)
+		bad("malformed devicetree row", NR)
+	print $2 > devicetree_out
+	next
+}
+{ bad("unknown manifest row", NR) }
+function bad(message, line) {
+	print message " at manifest line " line > "/dev/stderr"
+	failed = 1
+}
+END { exit failed }
+' config_out="$tmp/expected-config" site_out="$tmp/expected-sites" \
+	expanded_out="$tmp/expected-expanded" \
+	devicetree_out="$tmp/expected-devicetree" \
+	source_out="$tmp/manifest-sources" "$manifest"
+
+[ "$(wc -l < "$tmp/expected-devicetree")" -eq 1 ] || {
+	echo "missing generated devicetree evidence" >&2
+	exit 1
+}
+actual_devicetree=$(sha256sum "$devicetree" | awk '{print $1}')
+expected_devicetree=$(cat "$tmp/expected-devicetree")
+[ "$actual_devicetree" = "$expected_devicetree" ] || {
+	echo "generated devicetree drift: expected $expected_devicetree, got $actual_devicetree" >&2
+	exit 1
+}
+
+for required in CONFIG_PCI_ALLOW_BUS_MASTER_ANY_DEVICE \
+	CONFIG_PCI_SET_BUS_MASTER_PCI_BRIDGES CONFIG_PAYLOAD_OWNS_PCI_DEVICES \
+	CONFIG_RUN_FSP_GOP CONFIG_NO_GFX_INIT CONFIG_TCG_OPAL_S3_UNLOCK \
+	CONFIG_CONSOLE_SERIAL; do
+	grep -q "^${required}$(printf '\t')" "$tmp/expected-config" || {
+		echo "missing required policy input: $required" >&2
+		exit 1
+	}
+done
+
+while IFS="$(printf '\t')" read -r symbol expected; do
+	case "$expected" in
+	y) grep -qx "$symbol=y" "$config" || {
+		echo "resolved config drift: expected $symbol=y" >&2; exit 1; } ;;
+	n) grep -qx "# $symbol is not set" "$config" || {
+		echo "resolved config drift: expected $symbol=n" >&2; exit 1; } ;;
+	esac
+done < "$tmp/expected-config"
+
+sort -u "$sources" > "$tmp/sources"
+[ -s "$tmp/sources" ] || { echo "empty enabled-source graph" >&2; exit 1; }
+
+while IFS= read -r source; do
+	case "$source" in
+	""|..|/*|*../*|../*|*/..) echo "unsafe enabled source path: $source" >&2; exit 1 ;;
+	esac
+	[ -f "$tree/$source" ] || {
+		echo "stale enabled source: $source" >&2; exit 1;
+	}
+done < "$tmp/sources"
+
+sort -u "$tmp/manifest-sources" | while IFS= read -r source; do
+	grep -Fxq "$source" "$tmp/sources" || {
+		echo "manifest source is not in resolved build graph: $source" >&2
+		exit 1
+	}
+done
+
+: > "$tmp/actual-sites"
+while IFS= read -r source; do
+	contexts="$tmp/site-contexts"
+	if ! awk '
+	{
+		text[NR] = $0
+		semantic[NR] = semantic_text($0)
+	}
+	function semantic_text(source, output, cursor, character, next_character) {
+		output = ""
+		for (cursor = 1; cursor <= length(source); cursor++) {
+			character = substr(source, cursor, 1)
+			next_character = substr(source, cursor + 1, 1)
+			if (block_comment) {
+				if (character == "*" && next_character == "/") {
+					output = output "  "
+					cursor++
+					block_comment = 0
+				} else output = output " "
+				continue
+			}
+			if (string_quote != "") {
+				output = output " "
+				if (escaped) escaped = 0
+				else if (character == "\\") escaped = 1
+				else if (character == string_quote) string_quote = ""
+				continue
+			}
+			if (character == "/" && next_character == "*") {
+				output = output "  "
+				cursor++
+				block_comment = 1
+				continue
+			}
+			if (character == "/" && next_character == "/")
+				return output
+			if (character == "\"" || character == "\047") {
+				output = output " "
+				string_quote = character
+				continue
+			}
+			output = output character
+		}
+		return output
+	}
+	function statement_prefix(line, prefix, position, part) {
+		prefix = ""
+		for (position = line - 1; position > 0; position--) {
+			part = semantic[position]
+			if (part ~ /[;{}]/) {
+				sub(/^.*[;{}]/, "", part)
+				return part " " prefix
+			}
+			prefix = part " " prefix
+		}
+		return prefix
+	}
+	function following_semantic(source, line, position) {
+		position = line + 1
+		while (source ~ /^[[:space:]]*$/ && position <= NR) {
+			source = source " " semantic[position]
+			position++
+		}
+		return source
+	}
+	function helper_reference(source, helper, declaration_prefix, line,
+				  rest, before, after, following, prefix, suffix) {
+		rest = source
+		while (match(rest, helper)) {
+			before = substr(rest, 1, RSTART - 1)
+			after = substr(rest, RSTART + RLENGTH)
+			following = following_semantic(after, line)
+			prefix = substr(before, length(before), 1)
+			suffix = substr(after, 1, 1)
+			if ((prefix == "" || prefix !~ /[A-Za-z0-9_]/) &&
+			    (suffix == "" || suffix !~ /[A-Za-z0-9_]/) &&
+			    !(following ~ /^[[:space:]]*\(/ &&
+			      helper_declarator(declaration_prefix before)))
+				return 1
+			rest = after
+		}
+		return 0
+	}
+	function helper_declarator(before, declaration) {
+		declaration = before
+		sub(/^.*[;{}]/, "", declaration)
+		gsub(/__attribute__[[:space:]]*\(\([^)]*\)\)[[:space:]]*/, "", declaration)
+		return declaration ~ /^[[:space:]]*((extern|static|inline|__always_inline|__weak)[[:space:]]+)*void[[:space:]]+([A-Za-z_][A-Za-z0-9_]*[[:space:]]+)*$/
+	}
+	END {
+		for (line = 1; line <= NR; line++) {
+			if (semantic[line] !~ /pci_dev_(request|disable)_bus_master|PCI_COMMAND_MASTER/)
+				continue
+			context = ""
+			first = line > 2 ? line - 2 : 1
+			last = line + 2 < NR ? line + 2 : NR
+			for (position = first; position <= last; position++) {
+				part = semantic[position]
+				gsub(/^[[:space:]]+|[[:space:]]+$/, "", part)
+				gsub(/[[:space:]]+/, " ", part)
+				if (part != "")
+					context = context (context == "" ? "" : " ") part
+			}
+			prefix = statement_prefix(line)
+			request = helper_reference(semantic[line],
+				"pci_dev_request_bus_master", prefix, line)
+			disable = helper_reference(semantic[line],
+				"pci_dev_disable_bus_master", prefix, line)
+			if (!request && !disable &&
+			    semantic[line] ~ /pci_dev_(request|disable)_bus_master/ &&
+			    semantic[line] !~ /PCI_COMMAND_MASTER/)
+				continue
+			if (!request && !disable &&
+			    context !~ /pci_[a-z_]*config(16|32).*PCI_COMMAND_MASTER/ &&
+				   context !~ /dev->command.*PCI_COMMAND_MASTER/ &&
+				   context !~ /(reg16|pcireg).*PCI_COMMAND_MASTER/ &&
+				   context !~ /#define UART_PCI_ENABLE.*PCI_COMMAND_MASTER/) {
+				print "unrecognized PCI_COMMAND_MASTER operation at " FILENAME ":" line > "/dev/stderr"
+				failed = 1
+				continue
+			}
+			operation = "command"
+			if (request) operation = "request"
+			if (disable) operation = "disable"
+			print line "\t" operation "\t" context
+		}
+		exit failed
+	}' "$tree/$source" > "$contexts"; then
+		exit 1
+	fi
+	while IFS="$(printf '\t')" read -r source_line operation context; do
+		state=enable
+		[ "$operation" != disable ] || state=disable
+		owner=coreboot
+		case "$context" in
+		*'~PCI_COMMAND_MASTER'*|*'~('*'PCI_COMMAND_MASTER'*) state=disable ;;
+		esac
+		case "$source" in
+		src/soc/intel/common/block/dsp/dsp.c)
+			if [ "$state" = disable ]; then class=dsp-finalize
+			else state=dormant; owner=payload; class=dsp-endpoint; fi ;;
+		src/soc/intel/common/block/hda/hda.c)
+			if [ "$state" = disable ]; then class=hda-finalize
+			else state=dormant; owner=payload; class=hda-endpoint; fi ;;
+		src/soc/intel/common/block/sata/sata.c)
+			if [ "$state" = disable ]; then class=sata-finalize
+			else state=dormant; owner=payload; class=sata-endpoint; fi ;;
+		src/soc/intel/common/block/gspi/gspi.c)
+			state=dormant
+			if [ "$source_line" -lt 150 ]; then class=gspi-early; else class=gspi-runtime; fi ;;
+		src/soc/intel/common/block/i2c/i2c.c)
+			if [ "$state" = disable ]; then class=i2c-finalize
+			else state=dormant; class=i2c-early; fi ;;
+		src/soc/intel/common/block/xhci/xhci.c) class=xhci-finalize ;;
+		src/soc/intel/common/feature/finalize/finalize.c) class=thunderbolt-finalize ;;
+		src/soc/intel/common/block/uart/uart.c) state=capability; class=uart-controller ;;
+		src/device/pci_device.c)
+			if [ "$state" = disable ]; then class=endpoint-helper
+			elif printf '%s\n' "$context" | grep -q PCI_BRIDGE; then class=bridge-resource
+			else class=system-class; fi ;;
+		src/security/tcg/opal_s3/opal_nvme.c)
+			if [ "$state" = disable ]; then class=opal-s3-error; else class=opal-s3-nvme; fi ;;
+		src/soc/intel/common/block/cse/cse.c)
+			if [ "$source_line" -lt 500 ]; then class=cse-early; else class=cse-state; fi ;;
+		src/soc/intel/common/block/fast_spi/fast_spi.c) class=fast-spi-early ;;
+		src/soc/intel/common/block/graphics/graphics.c) class=graphics-endpoint ;;
+		src/soc/intel/common/block/p2sb/p2sblib.c) class=p2sb-platform ;;
+		src/soc/intel/common/block/pcie/pcie.c) class=pcie-bridge ;;
+		src/soc/intel/common/block/smm/smihandler.c) class=smm-sweep ;;
+		src/soc/intel/meteorlake/bootblock/soc_die.c) class=pmc-bootblock ;;
+		src/owner.c) class=fixture ;;
+		*) echo "unclassified raw bus-master site: $source:$source_line" >&2; exit 1 ;;
+		esac
+		digest=$(printf '%s\n%s\n' "$source" "$context" | sha256sum | awk '{print $1}')
+		printf '%s\t%s\t%s\t%s\t%s\n' "$state" "$owner" "$class" "$source" "$digest" \
+			>> "$tmp/actual-sites"
+	done < "$contexts"
+done < "$tmp/sources"
+
+sort "$tmp/expected-sites" > "$tmp/expected-sites.sorted"
+sort "$tmp/actual-sites" > "$tmp/actual-sites.sorted"
+if ! cmp -s "$tmp/expected-sites.sorted" "$tmp/actual-sites.sorted"; then
+	echo "PCI bus-master site inventory drift:" >&2
+	diff -u "$tmp/expected-sites.sorted" "$tmp/actual-sites.sorted" >&2 || true
+	exit 1
+fi
+
+: > "$tmp/expanded-statements.unsorted"
+while IFS="$(printf '\t')" read -r stage unit; do
+	case "$stage" in
+	bootblock|romstage|postcar|ramstage|smm|verstage) ;;
+	*) echo "invalid preprocessed stage: $stage" >&2; exit 1 ;;
+	esac
+	[ -f "$unit" ] || { echo "stale preprocessed unit: $unit" >&2; exit 1; }
+	if ! awk '
+	/^#[[:space:]]+[0-9]+[[:space:]]+"/ { source_line = $2; source_file = $3; next }
+	{
+		count = split($0, pieces, /;/)
+		for (piece = 1; piece <= count; piece++) {
+			print "# " source_line " " source_file
+			print pieces[piece] (piece < count ? ";" : "")
+		}
+		source_line++
+	}' "$unit" > "$tmp/preprocessed-statements"; then
+		exit 1
+	fi
+	if ! awk -v root="$tree/" -v stage="$stage" '
+	/^#[[:space:]]+[0-9]+[[:space:]]+"/ {
+		line = $2
+		file = $3
+		gsub(/^"|"$/, "", file)
+		if (index(file, root) == 1)
+			file = substr(file, length(root) + 1)
+		else if (match(file, /\/build\//))
+			file = "generated/" substr(file, RSTART + 7)
+		next
+	}
+	{
+		if (statement == "") {
+			origin = file
+			origin_line = line
+		}
+		line++
+		part = $0
+		gsub(/^[[:space:]]+|[[:space:]]+$/, "", part)
+		gsub(/[[:space:]]+/, " ", part)
+		statement = statement (statement == "" ? "" : " ") part
+		if ($0 !~ /;/) next
+		record_enum_constants(statement)
+		mutator = statement ~ /pci_[a-z_]*(or|and|write|update)_config(8|16|32)[[:space:]]*\(/
+		width = mutator ? access_width(statement) : 0
+		offset = mutator ? resolved_offset(argument(statement, 2)) : -1
+		offset_kind = mutator ? classify_offset(offset, width) : ""
+		request_helper = helper_invocation(statement, "pci_dev_request_bus_master")
+		disable_helper = helper_invocation(statement, "pci_dev_disable_bus_master")
+		if ((mutator && offset_kind != "other") || request_helper || disable_helper ||
+		    statement ~ /->[[:space:]]*command[[:space:]]*[|&^]?=/) {
+			state = "unknown"
+			class = "command-register"
+			if (offset_kind == "unknown") class = "unknown-overlap"
+			else if (offset_kind == "overlap") class = "command-overlap"
+			bme_bit = offset_kind == "unknown" ? -1 : bme_access_bit(offset, width)
+			if (request_helper ||
+			    (bme_bit >= 0 && statement ~ /pci_[a-z_]*or_config(8|16|32)/ &&
+			     has_bit(argument(statement, 3), bme_bit)) ||
+			    (bme_bit >= 0 && statement ~ /pci_[a-z_]*(write|update)_config(8|16|32)/ &&
+			     has_bit(argument(statement, statement ~ /update_config/ ? 4 : 3), bme_bit)) ||
+			    statement ~ /->[[:space:]]*command[[:space:]]*\|=.*([ (]|^)(4|0x0*4)([ );]|$)/)
+				state = "enable"
+			else if (disable_helper)
+				state = "disable"
+			else if ((bme_bit >= 0 && statement ~ /pci_[a-z_]*and_config(8|16|32)/ &&
+				  argument(statement, 3) ~ /~/ && has_bit(argument(statement, 3), bme_bit)) ||
+				 (bme_bit >= 0 && statement ~ /pci_[a-z_]*update_config(8|16|32)/ &&
+				  argument(statement, 3) ~ /~/ &&
+				  has_bit(argument(statement, 3), bme_bit) &&
+				  bit_is_known_clear(argument(statement, 4), bme_bit)) ||
+				 (bme_bit >= 0 && statement ~ /pci_[a-z_]*write_config(8|16|32)/ &&
+				  bit_is_known_clear(argument(statement, 3), bme_bit)) ||
+				 statement ~ /->[[:space:]]*command[[:space:]]*&=[[:space:]]*~.*(4|0x0*4)/)
+				state = "disable"
+			owner = "coreboot"
+			if (origin ~ /src\/soc\/intel\/common\/block\/(hda|dsp|sata)\// &&
+			    statement ~ /pci_dev_request_bus_master/) {
+				owner = "payload"
+				state = "dormant"
+			}
+			print state "\t" owner "\t" class "\t" stage "\t" origin "\t" origin_line "\t" statement
+		}
+		statement = ""
+	}
+	function helper_invocation(source, helper, rest, before) {
+		rest = source
+		while (match(rest, helper "[[:space:]]*\\(")) {
+			before = substr(rest, 1, RSTART - 1)
+			if (!helper_declarator(before))
+				return 1
+			rest = substr(rest, RSTART + RLENGTH)
+		}
+		return 0
+	}
+	function helper_declarator(before, declaration) {
+		declaration = before
+		sub(/^.*[;{}]/, "", declaration)
+		gsub(/__attribute__[[:space:]]*\(\([^)]*\)\)[[:space:]]*/, "", declaration)
+		return declaration ~ /^[[:space:]]*((extern|static|inline|__always_inline|__weak)[[:space:]]+)*void[[:space:]]+([A-Za-z_][A-Za-z0-9_]*[[:space:]]+)*$/
+	}
+	function argument(text, wanted, start, position, depth, commas, character) {
+		match(text, /pci_[a-z_]*(or|and|write|update)_config(8|16|32)[[:space:]]*\(/)
+		if (!RSTART) return ""
+		start = RSTART + RLENGTH
+		depth = 0
+		commas = 0
+		for (position = start; position <= length(text); position++) {
+			character = substr(text, position, 1)
+			if (character == "(") depth++
+			else if (character == ")") {
+				if (depth == 0) return wanted == commas + 1 ? substr(text, start, position - start) : ""
+				depth--
+			} else if (character == "," && depth == 0) {
+				commas++
+				if (wanted == commas) return substr(text, start, position - start)
+				start = position + 1
+			}
+		}
+		return ""
+	}
+	function clean(expression) {
+		gsub(/[[:space:]()]/, "", expression)
+		return expression
+	}
+	function atom_value(atom, value, digit, shift, parts, left, right) {
+		shift = split(atom, parts, /<</)
+		if (shift == 2) {
+			left = atom_value(parts[1])
+			right = atom_value(parts[2])
+			if (left < 0 || right < 0 || right >= 63) return -1
+			return left * (2 ^ right)
+		}
+		if (shift != 1) return -1
+		sub(/[uUlL]+$/, "", atom)
+		if (atom ~ /^0[xX][0-9a-fA-F]+$/) {
+			sub(/^0[xX]/, "", atom)
+			value = 0
+			while (length(atom)) {
+				digit = index("0123456789abcdef", tolower(substr(atom, 1, 1))) - 1
+				value = value * 16 + digit
+				atom = substr(atom, 2)
+			}
+			return value
+		}
+		return atom ~ /^[0-9]+$/ ? atom + 0 : -1
+	}
+	function constant_value(expression, terms, count, left, right) {
+		expression = clean(expression)
+		count = split(expression, terms, /\+/)
+		if (count == 1) return atom_value(terms[1])
+		if (count == 2) {
+			left = atom_value(terms[1]); right = atom_value(terms[2])
+			return left >= 0 && right >= 0 ? left + right : -1
+		}
+		return -1
+	}
+	function classify_offset(value, width, last_byte) {
+		if (value < 0) return "unknown"
+		last_byte = value + width / 8 - 1
+		if (last_byte < 4 || value > 5) return "other"
+		if (value == 4) return "command"
+		return "overlap"
+	}
+	function access_width(text, matched) {
+		match(text, /config(8|16|32)/)
+		matched = substr(text, RSTART + 6, RLENGTH - 6)
+		return matched + 0
+	}
+	function bme_access_bit(offset, width) {
+		if (offset > 4 || offset + width / 8 <= 4) return -1
+		return (4 - offset) * 8 + 2
+	}
+	function resolved_offset(expression, value, symbol) {
+		value = constant_value(expression)
+		symbol = clean(expression)
+		if (value < 0 && symbol in enum_value) value = enum_value[symbol]
+		return value
+	}
+	function has_bit(expression, bit, normalized, value, divisor, terms, count, index_) {
+		normalized = clean(expression)
+		divisor = 2 ^ bit
+		gsub(/~/, "", normalized)
+		count = split(normalized, terms, /\|/)
+		for (index_ = 1; index_ <= count; index_++) {
+			value = constant_value(terms[index_])
+			if (value >= 0 && int(value / divisor) % 2) return 1
+		}
+		return 0
+	}
+	function bit_is_known_clear(expression, bit, normalized, terms, count, index_, value, divisor) {
+		normalized = clean(expression)
+		if (normalized ~ /~/) return 0
+		divisor = 2 ^ bit
+		count = split(normalized, terms, /\|/)
+		for (index_ = 1; index_ <= count; index_++) {
+			value = constant_value(terms[index_])
+			if (value < 0 || int(value / divisor) % 2) return 0
+		}
+		return 1
+	}
+	function record_enum_constants(text, body, entries, count, index_, equals, name, expression, value) {
+		if (text !~ /enum[^{]*\{[^}]*\}/) return
+		body = text
+		sub(/^[^{]*\{/, "", body)
+		sub(/\}.*/, "", body)
+		count = split(body, entries, /,/)
+		for (index_ = 1; index_ <= count; index_++) {
+			equals = index(entries[index_], "=")
+			if (!equals) continue
+			name = substr(entries[index_], 1, equals - 1)
+			expression = substr(entries[index_], equals + 1)
+			gsub(/[[:space:]]/, "", name)
+			if (name !~ /^[A-Za-z_][A-Za-z0-9_]*$/) continue
+			value = constant_value(expression)
+			if (value >= 0) enum_value[name] = value
+		}
+	}
+	' "$tmp/preprocessed-statements" >> "$tmp/expanded-statements.unsorted"; then
+		exit 1
+	fi
+done < "$preprocessed"
+sort -u "$tmp/expanded-statements.unsorted" > "$tmp/expanded-statements"
+
+while IFS="$(printf '\t')" read -r state owner class stage source source_line statement; do
+	case "$source" in
+	""|/*|..|../*|*../*|*/..) continue ;;
+	esac
+	digest=$(printf '%s:%s\n%s\n' "$source" "$source_line" "$statement" |
+		sha256sum | awk '{print $1}')
+	printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$state" "$owner" "$class" "$stage" "$source" "$digest" \
+		>> "$tmp/actual-expanded"
+done < "$tmp/expanded-statements"
+
+sort "$tmp/expected-expanded" > "$tmp/expected-expanded.sorted"
+sort -u "$tmp/actual-expanded" > "$tmp/actual-expanded.sorted"
+if ! cmp -s "$tmp/expected-expanded.sorted" "$tmp/actual-expanded.sorted"; then
+	echo "preprocessed PCI command mutation inventory drift:" >&2
+	diff -u "$tmp/expected-expanded.sorted" "$tmp/actual-expanded.sorted" >&2 || true
+	exit 1
+fi
+
+echo "StarBook MTL PCI bus-master ownership audit passed"

--- a/util/testing/Makefile.mk
+++ b/util/testing/Makefile.mk
@@ -11,6 +11,7 @@ test-help help::
 	@echo  '  test-tools           - Basic: Tests a basic list of tools.'
 	@echo  '  test-abuild          - Basic: Builds all platforms'
 	@echo  '  test-payloads        - Basic: Builds internal payloads'
+	@echo  '  test-pci-busmaster-ownership - Audit StarBook MTL BME ownership'
 	@echo  '  test-cleanup         - Basic: Cleans coreboot directories'
 	@echo  '  test-starbook-mtl-spi-console - Validate the out-of-tree SPI console config'
 	@echo
@@ -112,9 +113,19 @@ endif
 
 test-basic: test-lint test-tools test-abuild test-payloads test-cleanup
 
-test-lint:
+test-lint: test-pci-busmaster-ownership test-starbook-mtl-spi-console
 	util/lint/lint lint-stable $(JUNIT)
 	util/lint/lint lint-extended $(JUNIT)
+
+.PHONY: test-pci-busmaster-ownership
+test-pci-busmaster-ownership:
+	util/check-pci-busmaster-ownership-test.sh
+
+.PHONY: print-pci-busmaster-build-graph
+print-pci-busmaster-build-graph:
+	$(foreach class,$(classes),$(foreach source,$($(class)-srcs), \
+		$(info $(class)	$(source)	$(call src-to-obj,$(class),$(source)))))
+	@:
 
 test-abuild:
 ifneq ($(JENKINS_SKIP_STATIC_ANALYSIS_TEST),y)


### PR DESCRIPTION
## Summary

- derive the exact enabled StarBook MTL source/object/dependency graph
- inventory and classify PCI command/BME operations after preprocessing
- cover standard config8/16/32 mutators, macros, generated headers, numeric and overlapping accesses
- pin resolved PAYLOAD_OWNS and bridge/endpoint classifications
- fail on new, removed, duplicated, changed or reclassified operations
- bind external CDK2 NVMe evidence to exact commits while leaving it explicitly non-gating
- integrate the audit into test-lint

This PR deliberately does not change PCI_ALLOW_BUS_MASTER_ANY_DEVICE. It creates the machine-checkable ownership evidence required before tightening that policy.

## Validation

- production audit: 25 source sites / 118 configured expanded operations
- mutation suite for paths, comments, config drift, headers, generated code, offsets, widths, overlaps and classifications
- shell syntax, diff and stable lint
- independent final adversarial review at 80fe49f715
