### PR TITLE
mb/emulation/qemu-q35: link SMMSTORE in early stages

### DIFF
--- a/src/mainboard/emulation/qemu-q35/Makefile.mk
+++ b/src/mainboard/emulation/qemu-q35/Makefile.mk
@@ -1,11 +1,14 @@
 ## SPDX-License-Identifier: GPL-2.0-only
 
 bootblock-y += bootblock.c
+bootblock-y += rom_media_stub.c
 
 romstage-y += ../qemu-i440fx/memmap.c
+romstage-y += rom_media_stub.c
 
 postcar-y += ../qemu-i440fx/memmap.c
 postcar-y += ../qemu-i440fx/exit_car.S
+postcar-y += rom_media_stub.c
 
 ramstage-y += ../qemu-i440fx/memmap.c
 ramstage-y += ../qemu-i440fx/northbridge.c

--- a/src/mainboard/emulation/qemu-q35/rom_media_stub.c
+++ b/src/mainboard/emulation/qemu-q35/rom_media_stub.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <boot_device.h>
+
+/*
+ * SMMSTORE is linked into every standard stage, but writable flash is only
+ * initialized and consumed in ramstage and SMM.  Keep the earlier-stage
+ * reference linkable without probing QEMU's command-mode pflash before DRAM.
+ */
+const struct region_device *boot_device_rw(void)
+{
+	return NULL;
+}


### PR DESCRIPTION
## Summary

Make the Q35 SMMSTORE backend available in the stages that own the service.

This is a linear stack; `26.08` must land first.

## Validation

- DCO trailers on every commit
- QEMU Q35 build and focused handoff tests
- Final stacked validation is tracked on the terminal CDK2 integration PRs
