### PR TITLE
mb/qemu-q35: publish measured local APIC frequency

### DIFF
--- a/src/commonlib/include/commonlib/coreboot_tables.h
+++ b/src/commonlib/include/commonlib/coreboot_tables.h
@@ -3,6 +3,7 @@
 #ifndef COMMONLIB_COREBOOT_TABLES_H
 #define COMMONLIB_COREBOOT_TABLES_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 /* The coreboot table information is for conveying information
@@ -93,6 +94,7 @@ enum {
 	LB_TAG_ROOT_BRIDGE_INFO		= 0x0048,
 	LB_TAG_PANEL_POWEROFF		= 0x0049,
 	LB_TAG_SDHCI_NONPCI		= 0x004a,
+	LB_TAG_LOCAL_APIC_TIMER_INFO	= 0x004e,
 	/* The following options are CMOS-related */
 	LB_TAG_CMOS_OPTION_TABLE	= 0x00c8,
 	LB_TAG_OPTION			= 0x00c9,
@@ -135,6 +137,19 @@ struct lb_record {
 	uint32_t tag;		/* tag ID */
 	uint32_t size;		/* size of record (in bytes) */
 };
+
+struct lb_local_apic_timer_info {
+	uint32_t tag;
+	uint32_t size;
+	uint16_t revision;
+	uint16_t reserved;
+	lb_uint64_t frequency_hz;
+};
+
+_Static_assert(sizeof(struct lb_local_apic_timer_info) == 20,
+	"local APIC timer record ABI changed");
+_Static_assert(offsetof(struct lb_local_apic_timer_info, frequency_hz) == 12,
+	"local APIC timer frequency offset changed");
 
 struct lb_memory_range {
 	lb_uint64_t start;

--- a/src/mainboard/emulation/qemu-q35/Kconfig
+++ b/src/mainboard/emulation/qemu-q35/Kconfig
@@ -92,6 +92,14 @@ config HAVE_INTEL_FIRMWARE
 	bool
 	default n
 
+config PAYLOAD_LOCAL_APIC_TIMER_INFO
+	bool "Publish measured local APIC timer frequency to the payload"
+	default n
+	help
+	  Measure the QEMU local APIC timer against the ICH9 ACPI PM timer and
+	  publish the result in the coreboot table for payloads that require an
+	  authoritative timer input frequency.
+
 config DCACHE_BSP_STACK_SIZE
 	hex
 	default 0x4000

--- a/src/mainboard/emulation/qemu-q35/Makefile.mk
+++ b/src/mainboard/emulation/qemu-q35/Makefile.mk
@@ -14,6 +14,7 @@ ramstage-y += ../qemu-i440fx/memmap.c
 ramstage-y += ../qemu-i440fx/northbridge.c
 ramstage-y += ../qemu-i440fx/rom_media.c
 ramstage-y += cpu.c
+ramstage-$(CONFIG_PAYLOAD_LOCAL_APIC_TIMER_INFO) += lapic_timer.c
 
 all-y += ../qemu-i440fx/bootmode.c
 all-y += memmap.c

--- a/src/mainboard/emulation/qemu-q35/lapic_timer.c
+++ b/src/mainboard/emulation/qemu-q35/lapic_timer.c
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <arch/io.h>
+#include <boot/coreboot_tables.h>
+#include <console/console.h>
+#include <cpu/x86/lapic.h>
+#include <stdint.h>
+#include <southbridge/intel/i82801ix/i82801ix.h>
+
+#include "lapic_timer.h"
+
+#define ACPI_PM_TIMER_FREQUENCY_HZ 3579545U
+#define ACPI_PM_TIMER_MASK 0x00ffffffU
+#define ACPI_PM_TIMER_OFFSET 0x08U
+#define CALIBRATION_PM_TICKS (ACPI_PM_TIMER_FREQUENCY_HZ / 100U)
+#define CALIBRATION_POLL_LIMIT 10000000U
+
+static uint32_t elapsed24(uint32_t start, uint32_t end)
+{
+	return (end - start) & ACPI_PM_TIMER_MASK;
+}
+
+uint32_t q35_measure_lapic_timer_hz(const struct q35_lapic_timer_ops *ops,
+	uint32_t poll_limit)
+{
+	const uint32_t saved_lvtt = ops->lapic_read(LAPIC_LVTT);
+	const uint32_t saved_tdcr = ops->lapic_read(LAPIC_TDCR);
+	const uint32_t saved_tmict = ops->lapic_read(LAPIC_TMICT);
+	uint32_t start_pm, end_pm, start_lapic, end_lapic;
+	uint32_t pm_ticks, lapic_ticks, polls;
+	uint64_t frequency;
+
+	ops->lapic_write(LAPIC_LVTT, LAPIC_LVT_MASKED);
+	ops->lapic_write(LAPIC_TDCR, LAPIC_TDR_DIV_1);
+	ops->lapic_write(LAPIC_TMICT, UINT32_MAX);
+	start_pm = ops->pm_timer_read() & ACPI_PM_TIMER_MASK;
+	end_pm = start_pm;
+	start_lapic = ops->lapic_read(LAPIC_TMCCT);
+	for (polls = 0; polls < poll_limit; polls++) {
+		end_pm = ops->pm_timer_read() & ACPI_PM_TIMER_MASK;
+		if (elapsed24(start_pm, end_pm) >= CALIBRATION_PM_TICKS)
+			break;
+	}
+	end_lapic = ops->lapic_read(LAPIC_TMCCT);
+
+	ops->lapic_write(LAPIC_LVTT, LAPIC_LVT_MASKED);
+	ops->lapic_write(LAPIC_TDCR, saved_tdcr);
+	ops->lapic_write(LAPIC_TMICT, saved_tmict);
+	ops->lapic_write(LAPIC_LVTT, saved_lvtt);
+
+	if (polls == poll_limit)
+		return 0;
+	pm_ticks = elapsed24(start_pm, end_pm);
+	lapic_ticks = start_lapic - end_lapic;
+	if (pm_ticks == 0 || lapic_ticks == 0)
+		return 0;
+	frequency = (uint64_t)lapic_ticks * ACPI_PM_TIMER_FREQUENCY_HZ / pm_ticks;
+	if (frequency == 0 || frequency > UINT32_MAX)
+		return 0;
+	return frequency;
+}
+
+#ifndef __TEST__
+static uint32_t hardware_lapic_read(uint32_t reg) { return lapic_read(reg); }
+static void hardware_lapic_write(uint32_t reg, uint32_t value)
+{
+	lapic_write(reg, value);
+}
+static uint32_t hardware_pm_timer_read(void)
+{
+	return inl(DEFAULT_PMBASE + ACPI_PM_TIMER_OFFSET);
+}
+
+void lb_board(struct lb_header *header)
+{
+	struct lb_local_apic_timer_info *timer;
+	static const struct q35_lapic_timer_ops ops = {
+		hardware_lapic_read, hardware_lapic_write, hardware_pm_timer_read
+	};
+	uint32_t frequency_hz = q35_measure_lapic_timer_hz(&ops,
+		CALIBRATION_POLL_LIMIT);
+
+	if (frequency_hz == 0) {
+		printk(BIOS_ERR, "QEMU: failed to calibrate local APIC timer\n");
+		return;
+	}
+	timer = (void *)lb_new_record(header);
+	timer->tag = LB_TAG_LOCAL_APIC_TIMER_INFO;
+	timer->size = sizeof(*timer);
+	timer->revision = 1;
+	timer->reserved = 0;
+	timer->frequency_hz = frequency_hz;
+	printk(BIOS_INFO, "QEMU: local APIC timer measured at %u Hz\n", frequency_hz);
+}
+#endif

--- a/src/mainboard/emulation/qemu-q35/lapic_timer.h
+++ b/src/mainboard/emulation/qemu-q35/lapic_timer.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef MAINBOARD_EMULATION_QEMU_Q35_LAPIC_TIMER_H
+#define MAINBOARD_EMULATION_QEMU_Q35_LAPIC_TIMER_H
+
+#include <stdint.h>
+
+struct q35_lapic_timer_ops {
+	uint32_t (*lapic_read)(uint32_t reg);
+	void (*lapic_write)(uint32_t reg, uint32_t value);
+	uint32_t (*pm_timer_read)(void);
+};
+
+uint32_t q35_measure_lapic_timer_hz(const struct q35_lapic_timer_ops *ops,
+	uint32_t poll_limit);
+
+#endif

--- a/tests/mainboard/Makefile.mk
+++ b/tests/mainboard/Makefile.mk
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+.PHONY: q35-lapic-timer-host-test
+q35-lapic-timer-host-test:
+	@tests/mainboard/q35_lapic_timer_test.sh

--- a/tests/mainboard/q35-lapic-timer-test.c
+++ b/tests/mainboard/q35-lapic-timer-test.c
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/x86/lapic.h>
+
+#include "lapic_timer.h"
+
+#define PM_MASK 0x00ffffffU
+#define PM_TARGET 35795U
+
+static uint32_t registers[4];
+static uint32_t pm_start, pm_step, pm_reads;
+static uint32_t lapic_start, lapic_end, current_reads;
+static uint32_t write_registers[8], write_values[8], write_count;
+
+static size_t register_index(uint32_t reg)
+{
+	switch (reg) {
+	case LAPIC_LVTT: return 0;
+	case LAPIC_TDCR: return 1;
+	case LAPIC_TMICT: return 2;
+	default: return 3;
+	}
+}
+
+static uint32_t mock_lapic_read(uint32_t reg)
+{
+	if (reg == LAPIC_TMCCT)
+		return current_reads++ == 0U ? lapic_start : lapic_end;
+	return registers[register_index(reg)];
+}
+
+static void mock_lapic_write(uint32_t reg, uint32_t value)
+{
+	if (write_count < 8U) {
+		write_registers[write_count] = reg;
+		write_values[write_count] = value;
+	}
+	write_count++;
+	registers[register_index(reg)] = value;
+}
+
+static uint32_t mock_pm_read(void)
+{
+	uint32_t value = (pm_start + pm_reads * pm_step) & PM_MASK;
+	pm_reads++;
+	return value;
+}
+
+static const struct q35_lapic_timer_ops ops = {
+	mock_lapic_read, mock_lapic_write, mock_pm_read
+};
+
+static void reset_fixture(void)
+{
+	registers[0] = 0x12345678U;
+	registers[1] = 0x9abcdef0U;
+	registers[2] = 0x13579bdfU;
+	pm_start = PM_MASK - 100U;
+	pm_step = PM_TARGET;
+	pm_reads = current_reads = write_count = 0U;
+	lapic_start = UINT32_MAX;
+	lapic_end = UINT32_MAX - 10000000U;
+}
+
+static int registers_restored(void)
+{
+	return registers[0] == 0x12345678U && registers[1] == 0x9abcdef0U &&
+		registers[2] == 0x13579bdfU;
+}
+
+static int programming_sequence_valid(void)
+{
+	return write_count == 7U &&
+		write_registers[0] == LAPIC_LVTT &&
+		write_values[0] == LAPIC_LVT_MASKED &&
+		write_registers[1] == LAPIC_TDCR &&
+		write_values[1] == LAPIC_TDR_DIV_1 &&
+		write_registers[2] == LAPIC_TMICT &&
+		write_values[2] == UINT32_MAX &&
+		write_registers[3] == LAPIC_LVTT &&
+		write_values[3] == LAPIC_LVT_MASKED &&
+		write_registers[4] == LAPIC_TDCR &&
+		write_values[4] == 0x9abcdef0U &&
+		write_registers[5] == LAPIC_TMICT &&
+		write_values[5] == 0x13579bdfU &&
+		write_registers[6] == LAPIC_LVTT &&
+		write_values[6] == 0x12345678U;
+}
+
+static int check(int condition, const char *message)
+{
+	(void)message;
+	return !condition;
+}
+
+int main(void)
+{
+	uint32_t frequency;
+	int failures = 0;
+
+	reset_fixture();
+	frequency = q35_measure_lapic_timer_hz(&ops, 4U);
+	failures += check(frequency > 999000000U && frequency < 1001000000U,
+		"24-bit wrap measurement was inaccurate");
+	failures += check(registers_restored(), "success did not restore LAPIC state");
+	failures += check(programming_sequence_valid(),
+		"calibration programming/restoration sequence was incorrect");
+	reset_fixture();
+	failures += check(q35_measure_lapic_timer_hz(&ops, 0U) == 0U,
+		"zero poll limit was accepted");
+	failures += check(registers_restored() && programming_sequence_valid(),
+		"zero poll limit did not restore LAPIC state");
+	reset_fixture();
+	pm_step = 0U;
+	failures += check(q35_measure_lapic_timer_hz(&ops, 3U) == 0U,
+		"stalled PM timer was accepted");
+	failures += check(registers_restored(), "stall did not restore LAPIC state");
+	reset_fixture();
+	lapic_end = lapic_start;
+	failures += check(q35_measure_lapic_timer_hz(&ops, 4U) == 0U,
+		"zero LAPIC delta was accepted");
+	failures += check(registers_restored(),
+		"zero LAPIC delta did not restore LAPIC state");
+	reset_fixture();
+	lapic_end = 0U;
+	failures += check(q35_measure_lapic_timer_hz(&ops, 4U) == 0U,
+		"overflowing LAPIC frequency was accepted");
+	failures += check(registers_restored(), "overflow did not restore LAPIC state");
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/mainboard/q35_lapic_timer_test.sh
+++ b/tests/mainboard/q35_lapic_timer_test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+temporary=$(mktemp -d)
+trap 'rm -rf "$temporary"' EXIT HUP INT TERM
+
+cc -std=gnu11 -Wall -Wextra -Werror -Wno-unused-parameter \
+	-D__TEST__ -D__COREBOOT__ \
+	-D__RAMSTAGE__ -fno-builtin -include "$root/src/include/kconfig.h" \
+	-include "$root/src/include/rules.h" \
+	-include "$root/src/commonlib/bsd/include/commonlib/bsd/compiler.h" \
+	-I"$root/src" -I"$root/src/include" -I"$root/src/commonlib/include" \
+	-I"$root/src/commonlib/bsd/include" -I"$root/src/arch/x86/include" \
+	-I"$root/build" \
+	-I"$root/src/mainboard/emulation/qemu-q35" \
+	"$root/tests/mainboard/q35-lapic-timer-test.c" \
+	"$root/src/mainboard/emulation/qemu-q35/lapic_timer.c" \
+	-o "$temporary/q35-lapic-timer-test"
+"$temporary/q35-lapic-timer-test"
+printf '%s\n' 'q35 LAPIC timer host tests: PASS'


### PR DESCRIPTION
## Summary

Add the common handoff ABI and publish the measured local APIC timer frequency for payload consumers.

This is a linear stack; `publish/q35-smmstore-stages` must land first.

## Validation

- DCO trailers on every commit
- QEMU Q35 build and focused handoff tests
- Final stacked validation is tracked on the terminal CDK2 integration PRs
