### PR TITLE
lib: validate platform-contained PCI apertures

### DIFF
--- a/src/lib/payload_resource_handoff.c
+++ b/src/lib/payload_resource_handoff.c
@@ -57,6 +57,7 @@ static bool platform_mmio_contains(const struct device *device,
 
 	return (resource->flags & IORESOURCE_TYPE_MASK) == IORESOURCE_MEM &&
 		(resource->flags & IORESOURCE_FIXED) &&
+		(resource->flags & IORESOURCE_RESERVE) &&
 		!(resource->flags & IORESOURCE_CACHEABLE) &&
 		(device->path.type != DEVICE_PATH_PCI || !resource_bar(resource, &bar)) &&
 		range_end(resource->base, resource->size, &resource_end) &&

--- a/src/lib/payload_resource_handoff.c
+++ b/src/lib/payload_resource_handoff.c
@@ -49,6 +49,20 @@ static bool resource_bar(const struct resource *resource, uint8_t *bar)
 	return true;
 }
 
+static bool platform_mmio_contains(const struct resource *resource, uint64_t base,
+	uint64_t end)
+{
+	uint64_t resource_end;
+	uint8_t bar;
+
+	return (resource->flags & IORESOURCE_TYPE_MASK) == IORESOURCE_MEM &&
+		(resource->flags & IORESOURCE_FIXED) &&
+		!(resource->flags & IORESOURCE_CACHEABLE) &&
+		!resource_bar(resource, &bar) &&
+		range_end(resource->base, resource->size, &resource_end) &&
+		resource->base <= base && end <= resource_end;
+}
+
 static const struct device *root_domain(const struct device *device)
 {
 	const struct bus *bus = device->upstream;
@@ -142,8 +156,11 @@ static bool assignment_valid(const struct device *device, const struct resource 
 			if ((other->flags & IORESOURCE_TYPE_MASK) !=
 			    (resource->flags & IORESOURCE_TYPE_MASK))
 				continue;
-			if (!range_end(other->base, other->size, &other_end) ||
-			    ranges_overlap(resource->base, end, other->base, other_end)) {
+			if (!range_end(other->base, other->size, &other_end))
+				return false;
+			if (ranges_overlap(resource->base, end, other->base, other_end)) {
+				if (platform_mmio_contains(other, resource->base, end))
+					continue;
 				printk(BIOS_ERR, "PRH: %s resource %lx overlaps %s resource %lx\n",
 				       dev_path(device), resource->index, dev_path(other_device),
 				       other->index);
@@ -185,7 +202,9 @@ static enum cb_err count_records(size_t *root_count, size_t *assignment_count)
 		if (!root_domain(device))
 			return CB_ERR;
 		for (resource = device->resource_list; resource; resource = resource->next) {
-			if (!resource_is_assignment(resource))
+			uint8_t bar;
+
+			if (!resource_is_assignment(resource) || !resource_bar(resource, &bar))
 				continue;
 			if (!assignment_valid(device, resource))
 				return CB_ERR;
@@ -284,15 +303,16 @@ enum cb_err lb_add_payload_resource_handoff(struct lb_header *header)
 		for (resource = device->resource_list; resource; resource = resource->next) {
 			struct lb_prh_pci_assignment *output;
 
-			if (!resource_is_assignment(resource))
+			uint8_t bar;
+
+			if (!resource_is_assignment(resource) || !resource_bar(resource, &bar))
 				continue;
 			output = &assignments[assignment_index++];
 			output->segment = bus->segment_group;
 			output->bus = device->upstream->secondary;
 			output->device = device->path.pci.devfn >> 3;
 			output->function = device->path.pci.devfn & 7;
-			if (!resource_bar(resource, &output->bar))
-				return CB_ERR;
+			output->bar = bar;
 			output->resource_type = assignment_type(resource);
 			output->flags = resource->flags & IORESOURCE_PCI64 ?
 				LB_PRH_PCI_ASSIGNMENT_64BIT : 0;

--- a/src/lib/payload_resource_handoff.c
+++ b/src/lib/payload_resource_handoff.c
@@ -49,8 +49,8 @@ static bool resource_bar(const struct resource *resource, uint8_t *bar)
 	return true;
 }
 
-static bool platform_mmio_contains(const struct resource *resource, uint64_t base,
-	uint64_t end)
+static bool platform_mmio_contains(const struct device *device,
+	const struct resource *resource, uint64_t base, uint64_t end)
 {
 	uint64_t resource_end;
 	uint8_t bar;
@@ -58,7 +58,7 @@ static bool platform_mmio_contains(const struct resource *resource, uint64_t bas
 	return (resource->flags & IORESOURCE_TYPE_MASK) == IORESOURCE_MEM &&
 		(resource->flags & IORESOURCE_FIXED) &&
 		!(resource->flags & IORESOURCE_CACHEABLE) &&
-		!resource_bar(resource, &bar) &&
+		(device->path.type != DEVICE_PATH_PCI || !resource_bar(resource, &bar)) &&
 		range_end(resource->base, resource->size, &resource_end) &&
 		resource->base <= base && end <= resource_end;
 }
@@ -137,7 +137,7 @@ static bool assignment_valid(const struct device *device, const struct resource 
 	for (other_device = all_devices; other_device; other_device = other_device->next) {
 		const struct resource *other;
 
-		if (!other_device->enabled || other_device->path.type != DEVICE_PATH_PCI)
+		if (!other_device->enabled)
 			continue;
 		for (other = other_device->resource_list; other; other = other->next) {
 			uint64_t other_end;
@@ -146,7 +146,8 @@ static bool assignment_valid(const struct device *device, const struct resource 
 			if (other == resource ||
 			    (!resource_is_assignment(other) && !resource_is_reserved(other)))
 				continue;
-			if (resource_bar(other, &other_bar) && other_device->upstream &&
+			if (other_device->path.type == DEVICE_PATH_PCI &&
+			    resource_bar(other, &other_bar) && other_device->upstream &&
 			    root_domain(other_device) == domain &&
 			    other_device->upstream->secondary == device->upstream->secondary &&
 			    other_device->path.pci.devfn == device->path.pci.devfn &&
@@ -159,7 +160,7 @@ static bool assignment_valid(const struct device *device, const struct resource 
 			if (!range_end(other->base, other->size, &other_end))
 				return false;
 			if (ranges_overlap(resource->base, end, other->base, other_end)) {
-				if (platform_mmio_contains(other, resource->base, end))
+				if (platform_mmio_contains(other_device, other, resource->base, end))
 					continue;
 				printk(BIOS_ERR, "PRH: %s resource %lx overlaps %s resource %lx\n",
 				       dev_path(device), resource->index, dev_path(other_device),

--- a/tests/lib/payload_resource_handoff-test.c
+++ b/tests/lib/payload_resource_handoff-test.c
@@ -232,6 +232,15 @@ static void test_platform_mmio_contains_bar(void **state)
 	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_SUCCESS);
 }
 
+static void test_unreserved_domain_mmio_containment_rejected(void **state)
+{
+	res[0].base = 0xfe03e000;
+	set_res(5, 0xfd800000, 0x01000000, IORESOURCE_MEM | IORESOURCE_ASSIGNED |
+		IORESOURCE_FIXED, 1, NULL);
+	devs[0].resource_list = &res[5];
+	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
+}
+
 static void test_platform_mmio_partial_overlap_rejected(void **state)
 {
 	res[0].base = 0xfe03e000;
@@ -411,6 +420,7 @@ int main(void)
 		cmocka_unit_test_setup(test_ecam, setup),
 		cmocka_unit_test_setup(test_skips_assigned_non_bar_io, setup),
 		cmocka_unit_test_setup(test_platform_mmio_contains_bar, setup),
+		cmocka_unit_test_setup(test_unreserved_domain_mmio_containment_rejected, setup),
 		cmocka_unit_test_setup(test_platform_mmio_partial_overlap_rejected, setup),
 		cmocka_unit_test_setup(test_platform_cacheable_containment_rejected, setup),
 		cmocka_unit_test_setup(test_platform_malformed_range_rejected, setup),

--- a/tests/lib/payload_resource_handoff-test.c
+++ b/tests/lib/payload_resource_handoff-test.c
@@ -183,16 +183,20 @@ static void test_rejects_devfn_narrowing(void **state)
 	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
 }
 
-static void test_rejects_high_resource_index(void **state)
+static void test_skips_non_bar_mmio_index(void **state)
 {
+	const struct lb_payload_resource_handoff *handoff;
+
 	res[0].index = 0x344;
-	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
+	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_SUCCESS);
+	handoff = get_handoff(*state);
+	assert_int_equal(handoff->sections[1].entry_count, 3);
 }
 
-static void test_rejects_narrowing_collision(void **state)
+static void test_skips_non_bar_low_byte_alias(void **state)
 {
 	res[0].index = 0x110;
-	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
+	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_SUCCESS);
 }
 
 static void test_reserved(void **state)
@@ -204,6 +208,36 @@ static void test_reserved(void **state)
 static void test_ecam(void **state)
 {
 	res[0].base = CONFIG_ECAM_MMCONF_BASE_ADDRESS;
+	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
+}
+
+static void test_skips_assigned_non_bar_io(void **state)
+{
+	const struct lb_payload_resource_handoff *handoff;
+
+	set_res(5, 0x1800, 0x80, IORESOURCE_IO | IORESOURCE_ASSIGNED |
+		IORESOURCE_FIXED, 1, NULL);
+	res[3].next = &res[5];
+	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_SUCCESS);
+	handoff = get_handoff(*state);
+	assert_int_equal(handoff->sections[1].entry_count, 4);
+}
+
+static void test_platform_mmio_contains_bar(void **state)
+{
+	res[0].base = 0xfe03e000;
+	set_res(5, 0xfd800000, 0x01000000, IORESOURCE_MEM | IORESOURCE_ASSIGNED |
+		IORESOURCE_FIXED | IORESOURCE_RESERVE, 1, NULL);
+	res[4].next = &res[5];
+	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_SUCCESS);
+}
+
+static void test_platform_mmio_partial_overlap_rejected(void **state)
+{
+	res[0].base = 0xfe03e000;
+	set_res(5, 0xfe03d800, 0x1000, IORESOURCE_MEM | IORESOURCE_ASSIGNED |
+		IORESOURCE_FIXED | IORESOURCE_RESERVE, 1, NULL);
+	res[4].next = &res[5];
 	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
 }
 
@@ -351,10 +385,13 @@ int main(void)
 		cmocka_unit_test_setup(test_rejects_above4g_non_pci64, setup),
 		cmocka_unit_test_setup(test_rejects_pci64_io, setup),
 		cmocka_unit_test_setup(test_rejects_devfn_narrowing, setup),
-		cmocka_unit_test_setup(test_rejects_high_resource_index, setup),
-		cmocka_unit_test_setup(test_rejects_narrowing_collision, setup),
+		cmocka_unit_test_setup(test_skips_non_bar_mmio_index, setup),
+		cmocka_unit_test_setup(test_skips_non_bar_low_byte_alias, setup),
 		cmocka_unit_test_setup(test_reserved, setup),
 		cmocka_unit_test_setup(test_ecam, setup),
+		cmocka_unit_test_setup(test_skips_assigned_non_bar_io, setup),
+		cmocka_unit_test_setup(test_platform_mmio_contains_bar, setup),
+		cmocka_unit_test_setup(test_platform_mmio_partial_overlap_rejected, setup),
 		cmocka_unit_test_setup(test_two_roots_same_segment, setup),
 		cmocka_unit_test_setup(test_overlapping_roots, setup),
 		cmocka_unit_test_setup(test_orphan, setup),

--- a/tests/lib/payload_resource_handoff-test.c
+++ b/tests/lib/payload_resource_handoff-test.c
@@ -227,8 +227,8 @@ static void test_platform_mmio_contains_bar(void **state)
 {
 	res[0].base = 0xfe03e000;
 	set_res(5, 0xfd800000, 0x01000000, IORESOURCE_MEM | IORESOURCE_ASSIGNED |
-		IORESOURCE_FIXED | IORESOURCE_RESERVE, 1, NULL);
-	res[4].next = &res[5];
+		IORESOURCE_FIXED | IORESOURCE_RESERVE, PCI_BASE_ADDRESS_0, NULL);
+	devs[0].resource_list = &res[5];
 	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_SUCCESS);
 }
 
@@ -237,7 +237,27 @@ static void test_platform_mmio_partial_overlap_rejected(void **state)
 	res[0].base = 0xfe03e000;
 	set_res(5, 0xfe03d800, 0x1000, IORESOURCE_MEM | IORESOURCE_ASSIGNED |
 		IORESOURCE_FIXED | IORESOURCE_RESERVE, 1, NULL);
-	res[4].next = &res[5];
+	devs[0].resource_list = &res[5];
+	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
+}
+
+static void test_platform_cacheable_containment_rejected(void **state)
+{
+	res[0].base = 0xfe03e000;
+	set_res(5, 0xfd800000, 0x01000000, IORESOURCE_MEM | IORESOURCE_ASSIGNED |
+		IORESOURCE_FIXED | IORESOURCE_CACHEABLE, 1, NULL);
+	devs[0].resource_list = &res[5];
+	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
+}
+
+static void test_platform_malformed_range_rejected(void **state)
+{
+	res[0].base = UINT64_MAX - 0x7ff;
+	res[0].size = 0x400;
+	res[0].flags |= IORESOURCE_PCI64;
+	set_res(5, UINT64_MAX - 0xfff, 0x2000, IORESOURCE_MEM | IORESOURCE_ASSIGNED |
+		IORESOURCE_FIXED | IORESOURCE_RESERVE, 1, NULL);
+	devs[0].resource_list = &res[5];
 	assert_int_equal(lb_add_payload_resource_handoff(*state), CB_ERR);
 }
 
@@ -392,6 +412,8 @@ int main(void)
 		cmocka_unit_test_setup(test_skips_assigned_non_bar_io, setup),
 		cmocka_unit_test_setup(test_platform_mmio_contains_bar, setup),
 		cmocka_unit_test_setup(test_platform_mmio_partial_overlap_rejected, setup),
+		cmocka_unit_test_setup(test_platform_cacheable_containment_rejected, setup),
+		cmocka_unit_test_setup(test_platform_malformed_range_rejected, setup),
 		cmocka_unit_test_setup(test_two_roots_same_segment, setup),
 		cmocka_unit_test_setup(test_overlapping_roots, setup),
 		cmocka_unit_test_setup(test_orphan, setup),


### PR DESCRIPTION
## Summary

Accept only BARs contained by authoritative platform resources and require reserved MMIO apertures.

This is a linear stack; `publish/q35-pci-identities` must land first.

## Validation

- DCO trailers on every commit
- QEMU Q35 build and focused handoff tests
- Final stacked validation is tracked on the terminal CDK2 integration PRs
