### PR TITLE
lib: publish delegated framebuffer ownership

### DIFF
--- a/src/commonlib/include/commonlib/coreboot_tables.h
+++ b/src/commonlib/include/commonlib/coreboot_tables.h
@@ -187,6 +187,8 @@ struct lb_pcie {
 
 #define LB_PRH_SECTION_PCI_ROOT_BRIDGES 3
 #define LB_PRH_SECTION_PCI_ASSIGNMENTS  4
+#define LB_PRH_SECTION_MEMORY_POLICY    1
+#define LB_PRH_SECTION_FRAMEBUFFER      7
 
 #define LB_PRH_PCI_ROOT_TOPOLOGY_ONLY 0x00000001
 
@@ -198,6 +200,10 @@ struct lb_pcie {
 #define LB_PRH_PCI_ASSIGNMENT_64BIT 0x01
 #define LB_PRH_PCI_MAX_ROOTS       16
 #define LB_PRH_PCI_MAX_ASSIGNMENTS 256
+#define LB_PRH_GCD_MEMORY_TYPE_MMIO 3
+#define LB_PRH_MEMORY_GCD_AUTHORITATIVE 0x00000004
+#define LB_PRH_FRAMEBUFFER_GEOMETRY_AUTHORITATIVE 0x00000001
+#define LB_PRH_FRAMEBUFFER_MEMORY_DELEGATED       0x80000000
 #define LB_PRH_SECTION_FLAG_MANDATORY     0x0001
 #define LB_PRH_SECTION_FLAG_AUTHORITATIVE 0x0002
 
@@ -259,6 +265,36 @@ struct lb_prh_pci_assignment {
 	lb_uint64_t attributes;
 };
 
+struct lb_prh_memory_policy {
+	lb_uint64_t base;
+	lb_uint64_t length;
+	lb_uint64_t capabilities;
+	lb_uint64_t attributes;
+	uint32_t gcd_type;
+	uint32_t efi_memory_type;
+	uint32_t owner_flags;
+	uint32_t reserved;
+};
+
+struct lb_prh_framebuffer {
+	lb_uint64_t physical_address;
+	lb_uint64_t size;
+	uint32_t x_resolution;
+	uint32_t y_resolution;
+	uint32_t bytes_per_line;
+	uint8_t bits_per_pixel;
+	uint8_t red_mask_pos;
+	uint8_t red_mask_size;
+	uint8_t green_mask_pos;
+	uint8_t green_mask_size;
+	uint8_t blue_mask_pos;
+	uint8_t blue_mask_size;
+	uint8_t reserved_mask_pos;
+	uint8_t reserved_mask_size;
+	uint8_t reserved[3];
+	uint32_t owner_flags;
+};
+
 _Static_assert(sizeof(struct lb_payload_resource_handoff) == 44,
 	       "unexpected payload resource handoff header size");
 _Static_assert(sizeof(struct lb_payload_resource_section) == 20,
@@ -267,6 +303,10 @@ _Static_assert(sizeof(struct lb_prh_pci_root_bridge) == 88,
 	       "unexpected payload resource root bridge size");
 _Static_assert(sizeof(struct lb_prh_pci_assignment) == 32,
 	       "unexpected payload resource PCI assignment size");
+_Static_assert(sizeof(struct lb_prh_memory_policy) == 48,
+	       "unexpected payload resource memory policy size");
+_Static_assert(sizeof(struct lb_prh_framebuffer) == 44,
+	       "unexpected payload resource framebuffer size");
 _Static_assert(_Alignof(struct lb_pcie) == 4,
 	       "lb_uint64_t alignment doesn't work as expected for struct lb_pcie!");
 

--- a/src/include/boot/coreboot_tables.h
+++ b/src/include/boot/coreboot_tables.h
@@ -46,6 +46,7 @@ void lb_efi_capsules(struct lb_header *header);
 /* Define this function to get the frame buffer returning lb_framebuffer object
    on success and NULL on error. */
 const struct lb_framebuffer *get_lb_framebuffer(void);
+const struct lb_framebuffer *payload_resource_framebuffer(void);
 
 /* Allow arch to add records. */
 void lb_arch_add_records(struct lb_header *header);

--- a/src/lib/payload_resource_handoff.c
+++ b/src/lib/payload_resource_handoff.c
@@ -7,8 +7,14 @@
 #include <device/device.h>
 #include <device/pci_def.h>
 #include <device/pci_ops.h>
+#include <framebuffer_info.h>
 #include <string.h>
 #include <version.h>
+
+__weak const struct lb_framebuffer *payload_resource_framebuffer(void)
+{
+	return get_lb_framebuffer();
+}
 
 static bool range_end(uint64_t base, uint64_t length, uint64_t *end)
 {
@@ -283,37 +289,119 @@ static enum cb_err quiesce_assigned_devices(void)
 	return CB_SUCCESS;
 }
 
+static bool framebuffer_mask_valid(uint8_t position, uint8_t size, uint8_t bpp,
+	uint32_t *mask)
+{
+	if (!size) {
+		*mask = 0;
+		return position == 0;
+	}
+	if (position >= bpp || size > bpp - position)
+		return false;
+	*mask = size == 32 ? UINT32_MAX : ((1U << size) - 1U) << position;
+	return true;
+}
+
+static enum cb_err validate_framebuffer(const struct lb_framebuffer *framebuffer,
+	uint64_t *length)
+{
+	uint32_t red, green, blue, reserved;
+	uint64_t minimum_stride;
+	unsigned int assignment_matches = 0;
+	const struct device *device;
+
+	if (!framebuffer) {
+		*length = 0;
+		return CB_SUCCESS;
+	}
+	if (!framebuffer->x_resolution || !framebuffer->y_resolution ||
+	    !framebuffer->bits_per_pixel ||
+	    framebuffer->bits_per_pixel > 32 ||
+	    framebuffer->orientation != LB_FB_ORIENTATION_NORMAL || framebuffer->pad ||
+	    framebuffer->flags.reserved ||
+	    !framebuffer_mask_valid(framebuffer->red_mask_pos, framebuffer->red_mask_size,
+		framebuffer->bits_per_pixel, &red) ||
+	    !framebuffer_mask_valid(framebuffer->green_mask_pos, framebuffer->green_mask_size,
+		framebuffer->bits_per_pixel, &green) ||
+	    !framebuffer_mask_valid(framebuffer->blue_mask_pos, framebuffer->blue_mask_size,
+		framebuffer->bits_per_pixel, &blue) ||
+	    !framebuffer_mask_valid(framebuffer->reserved_mask_pos,
+		framebuffer->reserved_mask_size, framebuffer->bits_per_pixel, &reserved) ||
+	    !red || !green || !blue || (red & green) || (red & blue) ||
+	    (red & reserved) || (green & blue) ||
+	    (green & reserved) || (blue & reserved))
+		return CB_ERR;
+	minimum_stride = ((uint64_t)framebuffer->x_resolution *
+		framebuffer->bits_per_pixel + 7) / 8;
+	if (framebuffer->bytes_per_line < minimum_stride ||
+	    framebuffer->y_resolution > UINT64_MAX / framebuffer->bytes_per_line)
+		return CB_ERR;
+	*length = (uint64_t)framebuffer->bytes_per_line * framebuffer->y_resolution;
+	if (!range_end(framebuffer->physical_address, *length, &minimum_stride))
+		return CB_ERR;
+	for (device = all_devices; device; device = device->next) {
+		const struct resource *resource;
+
+		if (!device->enabled)
+			continue;
+		for (resource = device->resource_list; resource; resource = resource->next) {
+			uint64_t end;
+
+			if (!range_end(resource->base, resource->size, &end) ||
+			    resource->base > framebuffer->physical_address || end < minimum_stride)
+				continue;
+			if (device->path.type == DEVICE_PATH_PCI &&
+			    resource_is_assignment(resource) &&
+			    (resource->flags & IORESOURCE_MEM))
+				assignment_matches++;
+		}
+	}
+	return assignment_matches == 1 ? CB_SUCCESS : CB_ERR;
+}
+
 enum cb_err lb_add_payload_resource_handoff(struct lb_header *header)
 {
 	struct lb_payload_resource_handoff *handoff;
 	struct lb_payload_resource_section *root_section, *assignment_section;
+	struct lb_payload_resource_section *memory_section, *framebuffer_section;
 	struct lb_prh_pci_root_bridge *roots;
 	struct lb_prh_pci_assignment *assignments;
+	struct lb_prh_memory_policy *memory;
+	struct lb_prh_framebuffer *framebuffer_output;
+	const struct lb_framebuffer *framebuffer = payload_resource_framebuffer();
 	const struct device *device;
 	size_t root_count, assignment_count, root_index = 0, assignment_index = 0;
+	uint64_t framebuffer_length;
+	size_t section_count = framebuffer ? 4 : 2;
+	size_t fixed_size = sizeof(*handoff) + section_count * sizeof(*root_section) +
+		(framebuffer ? sizeof(*memory) + sizeof(*framebuffer_output) : 0);
 
-	if (!header || count_records(&root_count, &assignment_count) != CB_SUCCESS)
+	if (!header || count_records(&root_count, &assignment_count) != CB_SUCCESS ||
+	    validate_framebuffer(framebuffer, &framebuffer_length) != CB_SUCCESS)
 		return CB_ERR;
 	if (quiesce_assigned_devices() != CB_SUCCESS)
 		return CB_ERR;
 	if (root_count > UINT32_MAX || assignment_count > UINT32_MAX ||
-	    root_count > (UINT32_MAX - sizeof(*handoff) - 2 * sizeof(*root_section)) /
+	    fixed_size > UINT32_MAX ||
+	    root_count > (UINT32_MAX - fixed_size) /
 			 sizeof(*roots) ||
-	    assignment_count > (UINT32_MAX - sizeof(*handoff) - 2 * sizeof(*root_section) -
-				      root_count * sizeof(*roots)) / sizeof(*assignments))
+	    assignment_count > (UINT32_MAX - fixed_size - root_count * sizeof(*roots)) /
+			 sizeof(*assignments))
 		return CB_ERR;
 
 	handoff = (void *)lb_new_record(header);
-	handoff->size = sizeof(*handoff) + 2 * sizeof(*root_section) +
-		root_count * sizeof(*roots) + assignment_count * sizeof(*assignments);
+	handoff->size = sizeof(*handoff) + section_count * sizeof(*root_section) +
+		root_count * sizeof(*roots) + assignment_count * sizeof(*assignments) +
+		(framebuffer ? sizeof(*memory) + sizeof(*framebuffer_output) : 0);
 	memset(handoff, 0, handoff->size);
 	handoff->tag = LB_TAG_PAYLOAD_RESOURCE_HANDOFF;
-	handoff->size = sizeof(*handoff) + 2 * sizeof(*root_section) +
-		root_count * sizeof(*roots) + assignment_count * sizeof(*assignments);
+	handoff->size = sizeof(*handoff) + section_count * sizeof(*root_section) +
+		root_count * sizeof(*roots) + assignment_count * sizeof(*assignments) +
+		(framebuffer ? sizeof(*memory) + sizeof(*framebuffer_output) : 0);
 	handoff->revision = LB_PAYLOAD_RESOURCE_HANDOFF_REVISION;
 	handoff->header_length = sizeof(*handoff);
 	handoff->section_header_length = sizeof(*root_section);
-	handoff->section_count = 2;
+	handoff->section_count = section_count;
 	handoff->producer_stage = 1;
 	handoff->producer_generation = 1;
 	handoff->lifetime_flags = LB_PRH_LIFETIME_COLD_BOOT |
@@ -326,7 +414,7 @@ enum cb_err lb_add_payload_resource_handoff(struct lb_header *header)
 	root_section->header_length = sizeof(*root_section);
 	root_section->entry_size = sizeof(*roots);
 	root_section->entry_count = root_count;
-	root_section->offset = sizeof(*handoff) + 2 * sizeof(*root_section);
+	root_section->offset = sizeof(*handoff) + section_count * sizeof(*root_section);
 	root_section->length = root_count * sizeof(*roots);
 	assignment_section->type = LB_PRH_SECTION_PCI_ASSIGNMENTS;
 	assignment_section->flags = LB_PRH_SECTION_FLAG_AUTHORITATIVE;
@@ -337,6 +425,48 @@ enum cb_err lb_add_payload_resource_handoff(struct lb_header *header)
 	assignment_section->length = assignment_count * sizeof(*assignments);
 	roots = (void *)((uint8_t *)handoff + root_section->offset);
 	assignments = (void *)((uint8_t *)handoff + assignment_section->offset);
+	if (framebuffer) {
+		memory_section = &handoff->sections[2];
+		framebuffer_section = &handoff->sections[3];
+		memory_section->type = LB_PRH_SECTION_MEMORY_POLICY;
+		memory_section->flags = LB_PRH_SECTION_FLAG_AUTHORITATIVE;
+		memory_section->header_length = sizeof(*memory_section);
+		memory_section->entry_size = sizeof(*memory);
+		memory_section->entry_count = 1;
+		memory_section->offset = assignment_section->offset + assignment_section->length;
+		memory_section->length = sizeof(*memory);
+		framebuffer_section->type = LB_PRH_SECTION_FRAMEBUFFER;
+		framebuffer_section->flags = LB_PRH_SECTION_FLAG_AUTHORITATIVE;
+		framebuffer_section->header_length = sizeof(*framebuffer_section);
+		framebuffer_section->entry_size = sizeof(*framebuffer_output);
+		framebuffer_section->entry_count = 1;
+		framebuffer_section->offset = memory_section->offset + memory_section->length;
+		framebuffer_section->length = sizeof(*framebuffer_output);
+		memory = (void *)((uint8_t *)handoff + memory_section->offset);
+		framebuffer_output =
+			(void *)((uint8_t *)handoff + framebuffer_section->offset);
+		memory->base = framebuffer->physical_address;
+		memory->length = framebuffer_length;
+		memory->gcd_type = LB_PRH_GCD_MEMORY_TYPE_MMIO;
+		memory->owner_flags = LB_PRH_MEMORY_GCD_AUTHORITATIVE;
+		framebuffer_output->physical_address = framebuffer->physical_address;
+		framebuffer_output->size = framebuffer_length;
+		framebuffer_output->x_resolution = framebuffer->x_resolution;
+		framebuffer_output->y_resolution = framebuffer->y_resolution;
+		framebuffer_output->bytes_per_line = framebuffer->bytes_per_line;
+		framebuffer_output->bits_per_pixel = framebuffer->bits_per_pixel;
+		framebuffer_output->red_mask_pos = framebuffer->red_mask_pos;
+		framebuffer_output->red_mask_size = framebuffer->red_mask_size;
+		framebuffer_output->green_mask_pos = framebuffer->green_mask_pos;
+		framebuffer_output->green_mask_size = framebuffer->green_mask_size;
+		framebuffer_output->blue_mask_pos = framebuffer->blue_mask_pos;
+		framebuffer_output->blue_mask_size = framebuffer->blue_mask_size;
+		framebuffer_output->reserved_mask_pos = framebuffer->reserved_mask_pos;
+		framebuffer_output->reserved_mask_size = framebuffer->reserved_mask_size;
+		framebuffer_output->owner_flags =
+			LB_PRH_FRAMEBUFFER_GEOMETRY_AUTHORITATIVE |
+			LB_PRH_FRAMEBUFFER_MEMORY_DELEGATED;
+	}
 
 	for (device = all_devices; device; device = device->next) {
 		const struct resource *resource;

--- a/tests/lib/payload_resource_handoff_standalone_test.c
+++ b/tests/lib/payload_resource_handoff_standalone_test.c
@@ -7,12 +7,25 @@
 #include <string.h>
 
 static uint8_t storage[4096];
-static struct device domain, endpoint;
+static struct device domain, endpoint, second_endpoint;
 static struct bus root_bus;
 static struct resource bar;
+static struct resource aperture, second_resource;
+static struct lb_framebuffer framebuffer;
+static int framebuffer_present;
 static uint16_t command;
 static int stuck;
 struct device *all_devices;
+
+const struct lb_framebuffer *payload_resource_framebuffer(void)
+{
+	return framebuffer_present ? &framebuffer : NULL;
+}
+
+const struct lb_framebuffer *get_lb_framebuffer(void)
+{
+	return payload_resource_framebuffer();
+}
 
 int printk(int level, const char *format, ...)
 {
@@ -67,9 +80,14 @@ static void reset_fixture(void)
 	memset(&endpoint, 0, sizeof(endpoint));
 	memset(&root_bus, 0, sizeof(root_bus));
 	memset(&bar, 0, sizeof(bar));
+	memset(&aperture, 0, sizeof(aperture));
+	memset(&second_endpoint, 0, sizeof(second_endpoint));
+	memset(&second_resource, 0, sizeof(second_resource));
+	memset(&framebuffer, 0, sizeof(framebuffer));
 	domain.enabled = 1;
 	domain.path.type = DEVICE_PATH_DOMAIN;
 	domain.downstream = &root_bus;
+	domain.resource_list = &aperture;
 	domain.next = &endpoint;
 	root_bus.dev = &domain;
 	root_bus.subordinate = 0xff;
@@ -82,6 +100,22 @@ static void reset_fixture(void)
 	bar.size = 0x1000;
 	bar.index = PCI_BASE_ADDRESS_0;
 	bar.flags = IORESOURCE_MEM | IORESOURCE_ASSIGNED | IORESOURCE_STORED;
+	aperture.base = bar.base;
+	aperture.size = bar.size;
+	aperture.index = 0x1000;
+	aperture.flags = IORESOURCE_MEM | IORESOURCE_FIXED | IORESOURCE_RESERVE;
+	framebuffer = (struct lb_framebuffer) {
+		.physical_address = bar.base,
+		.x_resolution = 16,
+		.y_resolution = 16,
+		.bytes_per_line = 64,
+		.bits_per_pixel = 32,
+		.red_mask_pos = 16, .red_mask_size = 8,
+		.green_mask_pos = 8, .green_mask_size = 8,
+		.blue_mask_pos = 0, .blue_mask_size = 8,
+		.reserved_mask_pos = 24, .reserved_mask_size = 8,
+	};
+	framebuffer_present = 0;
 	all_devices = &domain;
 	command = PCI_COMMAND_MASTER | PCI_COMMAND_MEMORY;
 	stuck = 0;
@@ -97,7 +131,17 @@ int main(void)
 {
 	struct lb_header *header = (void *)storage;
 	const struct lb_payload_resource_handoff *handoff;
+	uint8_t first_record[4096];
+	uint32_t first_size;
 	int failures = 0;
+
+#define REJECT_FRAMEBUFFER(mutation, message) do { \
+	reset_fixture(); \
+	framebuffer_present = 1; \
+	mutation; \
+	failures += check(lb_add_payload_resource_handoff(header) == CB_ERR && \
+		header->table_entries == 0 && (command & PCI_COMMAND_MASTER), message); \
+} while (0)
 
 	reset_fixture();
 	failures += check(lb_add_payload_resource_handoff(header) == CB_SUCCESS,
@@ -113,6 +157,161 @@ int main(void)
 		"record CRC mismatch");
 	failures += check(!(command & PCI_COMMAND_MASTER),
 		"bus mastering remained enabled");
+	failures += check(handoff->size == sizeof(*handoff) +
+		2 * sizeof(struct lb_payload_resource_section) +
+		sizeof(struct lb_prh_pci_root_bridge) +
+		sizeof(struct lb_prh_pci_assignment) && handoff->section_count == 2 &&
+		handoff->sections[0].type == LB_PRH_SECTION_PCI_ROOT_BRIDGES &&
+		handoff->sections[1].type == LB_PRH_SECTION_PCI_ASSIGNMENTS &&
+		handoff->sections[0].offset == sizeof(*handoff) +
+			2 * sizeof(struct lb_payload_resource_section) &&
+		handoff->sections[1].offset == handoff->sections[0].offset +
+			handoff->sections[0].length,
+		"no-framebuffer record changed legacy layout");
+	first_size = handoff->size;
+	memcpy(first_record, handoff, first_size);
+	reset_fixture();
+	failures += check(lb_add_payload_resource_handoff(header) == CB_SUCCESS &&
+		((const struct lb_payload_resource_handoff *)(const void *)
+		 (storage + sizeof(*header)))->size == first_size &&
+		memcmp(first_record, storage + sizeof(*header), first_size) == 0,
+		"no-framebuffer serialization is not deterministic");
+
+	reset_fixture();
+	framebuffer_present = 1;
+	failures += check(lb_add_payload_resource_handoff(header) == CB_SUCCESS,
+		"valid framebuffer was rejected");
+	handoff = (const void *)(storage + sizeof(*header));
+	failures += check(handoff->section_count == 4 &&
+		handoff->sections[2].type == LB_PRH_SECTION_MEMORY_POLICY &&
+		handoff->sections[3].type == LB_PRH_SECTION_FRAMEBUFFER &&
+		handoff->sections[2].entry_count == 1 &&
+		handoff->sections[3].entry_count == 1 &&
+		record_crc(handoff) == handoff->crc32,
+		"framebuffer ownership sections are malformed");
+	{
+		const struct lb_prh_memory_policy *memory =
+			(const void *)((const uint8_t *)handoff + handoff->sections[2].offset);
+		const struct lb_prh_framebuffer *output =
+			(const void *)((const uint8_t *)handoff + handoff->sections[3].offset);
+
+		failures += check(memory->base == framebuffer.physical_address &&
+			memory->length == 1024 &&
+			memory->gcd_type == LB_PRH_GCD_MEMORY_TYPE_MMIO &&
+			memory->owner_flags == LB_PRH_MEMORY_GCD_AUTHORITATIVE &&
+			memory->capabilities == 0 && memory->attributes == 0 &&
+			memory->efi_memory_type == 0 && memory->reserved == 0 &&
+			output->physical_address == framebuffer.physical_address &&
+			output->size == 1024 &&
+			output->x_resolution == framebuffer.x_resolution &&
+			output->y_resolution == framebuffer.y_resolution &&
+			output->bytes_per_line == framebuffer.bytes_per_line &&
+			output->owner_flags ==
+				(LB_PRH_FRAMEBUFFER_GEOMETRY_AUTHORITATIVE |
+				 LB_PRH_FRAMEBUFFER_MEMORY_DELEGATED),
+			"framebuffer ownership content mismatch");
+	}
+	failures += check(handoff->sections[2].flags ==
+		LB_PRH_SECTION_FLAG_AUTHORITATIVE, "memory section flags mismatch");
+	failures += check(handoff->sections[2].header_length == sizeof(handoff->sections[2]),
+		"memory section header mismatch");
+	failures += check(handoff->sections[2].entry_size == sizeof(struct lb_prh_memory_policy),
+		"memory section entry mismatch");
+	failures += check(handoff->sections[2].length == sizeof(struct lb_prh_memory_policy),
+		"memory section length mismatch");
+	failures += check(handoff->sections[3].flags == LB_PRH_SECTION_FLAG_AUTHORITATIVE,
+		"framebuffer section flags mismatch");
+	failures += check(handoff->sections[3].header_length == sizeof(handoff->sections[3]),
+		"framebuffer section header mismatch");
+	failures += check(handoff->sections[3].entry_size == sizeof(struct lb_prh_framebuffer),
+		"framebuffer section entry mismatch");
+	failures += check(handoff->sections[3].length == sizeof(struct lb_prh_framebuffer),
+		"framebuffer section length mismatch");
+	failures += check(handoff->sections[2].offset + handoff->sections[2].length ==
+		handoff->sections[3].offset, "framebuffer section is not contiguous");
+	failures += check(handoff->sections[3].offset + handoff->sections[3].length ==
+		handoff->size, "framebuffer section does not end record");
+	((uint8_t *)(void *)handoff)[handoff->sections[3].offset] ^= 1U;
+	failures += check(record_crc(handoff) != handoff->crc32,
+		"framebuffer record mutation retained a valid CRC");
+	((uint8_t *)(void *)handoff)[handoff->sections[3].offset] ^= 1U;
+	first_size = handoff->size;
+	memcpy(first_record, handoff, first_size);
+	reset_fixture();
+	framebuffer_present = 1;
+	failures += check(lb_add_payload_resource_handoff(header) == CB_SUCCESS &&
+		memcmp(first_record, storage + sizeof(*header), first_size) == 0,
+		"framebuffer serialization is not deterministic");
+
+	reset_fixture();
+	framebuffer_present = 1;
+	framebuffer.bytes_per_line = 1;
+	failures += check(lb_add_payload_resource_handoff(header) == CB_ERR &&
+		header->table_entries == 0 && (command & PCI_COMMAND_MASTER),
+		"invalid framebuffer mutated publication or device ownership");
+
+	reset_fixture();
+	framebuffer_present = 1;
+	domain.resource_list = NULL;
+	failures += check(lb_add_payload_resource_handoff(header) == CB_SUCCESS,
+		"valid framebuffer without a redundant platform aperture was rejected");
+
+	reset_fixture();
+	framebuffer_present = 1;
+	aperture.base += 512;
+	aperture.size = 1024;
+	failures += check(lb_add_payload_resource_handoff(header) == CB_ERR &&
+		header->table_entries == 0 && (command & PCI_COMMAND_MASTER),
+		"framebuffer BAR overlapping a reserved platform resource was published");
+
+	reset_fixture();
+	framebuffer_present = 1;
+	framebuffer.bits_per_pixel = 16;
+	framebuffer.bytes_per_line = 32;
+	framebuffer.red_mask_pos = 11; framebuffer.red_mask_size = 5;
+	framebuffer.green_mask_pos = 5; framebuffer.green_mask_size = 6;
+	framebuffer.blue_mask_pos = 0; framebuffer.blue_mask_size = 5;
+	framebuffer.reserved_mask_pos = 0; framebuffer.reserved_mask_size = 0;
+	failures += check(lb_add_payload_resource_handoff(header) == CB_SUCCESS,
+		"valid internal 16bpp framebuffer without reserved mask was rejected");
+
+	REJECT_FRAMEBUFFER(framebuffer.x_resolution = 0, "zero framebuffer width accepted");
+	REJECT_FRAMEBUFFER(framebuffer.y_resolution = 0, "zero framebuffer height accepted");
+	REJECT_FRAMEBUFFER(framebuffer.bits_per_pixel = 0, "zero framebuffer bpp accepted");
+	REJECT_FRAMEBUFFER(framebuffer.bits_per_pixel = 33, "oversized framebuffer bpp accepted");
+	REJECT_FRAMEBUFFER(framebuffer.red_mask_size = 0, "missing red mask accepted");
+	REJECT_FRAMEBUFFER(framebuffer.red_mask_pos = 31,
+		"past-bpp framebuffer mask accepted");
+	REJECT_FRAMEBUFFER(framebuffer.green_mask_pos = 16,
+		"overlapping framebuffer masks accepted");
+	REJECT_FRAMEBUFFER(framebuffer.reserved_mask_size = 0;
+		framebuffer.reserved_mask_pos = 1, "absent mask with position accepted");
+	REJECT_FRAMEBUFFER(framebuffer.orientation = LB_FB_ORIENTATION_BOTTOM_UP,
+		"unsupported framebuffer orientation accepted");
+	REJECT_FRAMEBUFFER(framebuffer.pad = 1, "nonzero framebuffer pad accepted");
+	REJECT_FRAMEBUFFER(framebuffer.flags.reserved = 1,
+		"reserved framebuffer flags accepted");
+	REJECT_FRAMEBUFFER(framebuffer.physical_address = UINT64_MAX - 512,
+		"wrapping framebuffer range accepted");
+	REJECT_FRAMEBUFFER(framebuffer.x_resolution = UINT32_MAX;
+		framebuffer.bytes_per_line = UINT32_MAX,
+		"undersized rounded framebuffer stride accepted");
+	REJECT_FRAMEBUFFER(bar.size = 512, "partial framebuffer BAR accepted");
+	REJECT_FRAMEBUFFER(bar.flags &= ~IORESOURCE_ASSIGNED,
+		"unassigned framebuffer BAR accepted");
+	REJECT_FRAMEBUFFER(bar.flags &= ~IORESOURCE_STORED,
+		"unstored framebuffer BAR accepted");
+	REJECT_FRAMEBUFFER(bar.flags = IORESOURCE_IO | IORESOURCE_ASSIGNED |
+		IORESOURCE_STORED, "I/O framebuffer BAR accepted");
+	REJECT_FRAMEBUFFER(second_endpoint = endpoint;
+		second_resource = bar;
+		second_resource.index = PCI_BASE_ADDRESS_1;
+		second_endpoint.path.pci.devfn = PCI_DEVFN(3, 0);
+		second_endpoint.resource_list = &second_resource;
+		endpoint.next = &second_endpoint,
+		"duplicate framebuffer assignment accepted");
+
+#undef REJECT_FRAMEBUFFER
 
 	reset_fixture();
 	bar.flags &= ~IORESOURCE_STORED;


### PR DESCRIPTION
## Summary

Publish framebuffer ownership explicitly so the payload can adopt graphics without repeating platform setup.

This is a linear stack; `publish/q35-busmaster-quiesce` must land first.

## Validation

- DCO trailers on every commit
- QEMU Q35 build and focused handoff tests
- Final stacked validation is tracked on the terminal CDK2 integration PRs
