### PR TITLE
acpi: preserve Q35 capsule handoff across resets

### DIFF
--- a/src/acpi/acpi.c
+++ b/src/acpi/acpi.c
@@ -1585,6 +1585,7 @@ unsigned long write_acpi_tables(const unsigned long start)
 			xsdt = (acpi_xsdt_t *)current;
 			current += sizeof(acpi_xsdt_t);
 			current = acpi_align_current(current);
+			acpi_qemu_clear_xsdt(xsdt);
 
 			/*
 			 * Qemu only creates an RSDT.

--- a/src/acpi/acpi.c
+++ b/src/acpi/acpi.c
@@ -14,6 +14,7 @@
  */
 
 #include <acpi/acpi.h>
+#include "qemu_rsdp.h"
 #include <acpi/acpi_apei.h>
 #include <acpi/acpi_gnvs.h>
 #include <acpi/acpi_iort.h>
@@ -1567,7 +1568,10 @@ unsigned long write_acpi_tables(const unsigned long start)
 
 		current = fw;
 		current = acpi_align_current(current);
-		if (rsdp->xsdt_address == 0) {
+		/* QEMU republishes an ACPI 1.0 RSDP on every boot.  Do not inspect
+		 * bytes beyond that structure: on a firmware reset they can retain the
+		 * XSDT address that coreboot synthesized during the previous boot. */
+		if (acpi_qemu_rsdp_needs_xsdt(rsdp)) {
 			acpi_rsdt_t *existing_rsdt = (acpi_rsdt_t *)(uintptr_t)rsdp->rsdt_address;
 
 			/*

--- a/src/acpi/qemu_rsdp.h
+++ b/src/acpi/qemu_rsdp.h
@@ -4,6 +4,7 @@
 #define ACPI_QEMU_RSDP_H
 
 #include <acpi/acpi.h>
+#include <string.h>
 
 static inline bool acpi_qemu_rsdp_needs_xsdt(const acpi_rsdp_t *rsdp)
 {
@@ -11,6 +12,11 @@ static inline bool acpi_qemu_rsdp_needs_xsdt(const acpi_rsdp_t *rsdp)
 	 * short-circuited so stale or inaccessible trailing bytes are irrelevant. */
 	return rsdp->revision < 2 || rsdp->length < sizeof(*rsdp) ||
 		rsdp->xsdt_address == 0;
+}
+
+static inline void acpi_qemu_clear_xsdt(acpi_xsdt_t *xsdt)
+{
+	memset(xsdt, 0, sizeof(*xsdt));
 }
 
 #endif

--- a/src/acpi/qemu_rsdp.h
+++ b/src/acpi/qemu_rsdp.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef ACPI_QEMU_RSDP_H
+#define ACPI_QEMU_RSDP_H
+
+#include <acpi/acpi.h>
+
+static inline bool acpi_qemu_rsdp_needs_xsdt(const acpi_rsdp_t *rsdp)
+{
+	/* ACPI 1.x ends before length and xsdt_address.  Keep these checks
+	 * short-circuited so stale or inaccessible trailing bytes are irrelevant. */
+	return rsdp->revision < 2 || rsdp->length < sizeof(*rsdp) ||
+		rsdp->xsdt_address == 0;
+}
+
+#endif

--- a/src/drivers/efi/capsule_buffer.h
+++ b/src/drivers/efi/capsule_buffer.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef _EFI_CAPSULE_BUFFER_H_
+#define _EFI_CAPSULE_BUFFER_H_
+
+#include <commonlib/helpers.h>
+#include <bootmem.h>
+#include <memrange.h>
+
+static inline bool efi_capsule_pick_buffer(const struct memranges *ranges,
+	uint64_t data_size, uint64_t *base, uint64_t *size)
+{
+	const struct range_entry *entry;
+	uint64_t rounded;
+	uint64_t selected = 0;
+
+	if (ranges == NULL || base == NULL || size == NULL || data_size == 0 ||
+	    data_size > UINT64_MAX - (4 * KiB - 1))
+		return false;
+	rounded = ALIGN_UP(data_size, 4 * KiB);
+	memranges_each_entry(entry, ranges) {
+		uint64_t entry_base;
+		uint64_t entry_size;
+
+		if (range_entry_tag(entry) != BM_MEM_RAM)
+			continue;
+		entry_base = range_entry_base(entry);
+		entry_size = range_entry_size(entry);
+		if (entry_base >= 4ULL * GiB)
+			break;
+		if (entry_size > 4ULL * GiB - entry_base)
+			entry_size = 4ULL * GiB - entry_base;
+		if (entry_size >= rounded)
+			selected = entry_base + entry_size - rounded;
+	}
+	if (selected == 0)
+		return false;
+	*base = selected;
+	*size = rounded;
+	return true;
+}
+
+#endif

--- a/src/drivers/efi/capsules.c
+++ b/src/drivers/efi/capsules.c
@@ -10,6 +10,7 @@
 #include <cpu/x86/pae.h>
 #include <drivers/efi/efivars.h>
 #include <drivers/efi/capsules.h>
+#include <drivers/efi/capsule_buffer.h>
 #include <memrange.h>
 #include <smm_call.h>
 #include <smmstore.h>
@@ -103,7 +104,7 @@ struct memranges memory_map;
 static char pae_page_tables[20 * KiB] __aligned(4 * KiB);
 
 /* Where all coalesced capsules are located. */
-struct memory_range coalesce_buffer;
+static struct memory_range coalesce_buffer;
 
 /* Where individual coalesced capsules are located and their count. */
 static struct memory_range uefi_capsules[MAX_CAPSULES];
@@ -595,33 +596,12 @@ static void reserve_capsules(struct block_descr block_chain)
 static struct memory_range pick_buffer(uint64_t total_data_size)
 {
 	struct memory_range buffer = {0};
+	uint64_t base;
+	uint64_t size;
 
-	/* 4 * KiB is the alignment set by memranges_init(). */
-	total_data_size = ALIGN_UP(total_data_size, 4 * KiB);
-
-	const struct range_entry *r;
-	memranges_each_entry(r, &memory_map) {
-		if (range_entry_tag(r) != BM_MEM_RAM)
-			continue;
-
-		resource_t base = range_entry_base(r);
-		if (base >= 4ULL * GiB)
-			break;
-
-		/* Possibly reduce size to not deal with ranges that cross 4 GiB boundary. */
-		resource_t size = range_entry_size(r);
-		if (base + size > 4ULL * GiB)
-			size -= base + size - 4ULL * GiB;
-
-		if (size >= total_data_size) {
-			/*
-			 * To not create troubles for payloads prefer higher addresses:
-			 *  - use the top part of a suitable range
-			 *  - exit the loop only after hitting 4 GiB boundary or end of the list
-			 */
-			buffer.base = base + size - total_data_size;
-			buffer.len = total_data_size;
-		}
+	if (efi_capsule_pick_buffer(&memory_map, total_data_size, &base, &size)) {
+		buffer.base = base;
+		buffer.len = size;
 	}
 
 	return buffer;
@@ -715,6 +695,10 @@ void efi_parse_capsules(void)
 		       IORESOURCE_ASSIGNED | IORESOURCE_CACHEABLE, IORESOURCE_MEM |
 		       IORESOURCE_FIXED | IORESOURCE_STORED | IORESOURCE_ASSIGNED |
 		       IORESOURCE_CACHEABLE, BM_MEM_RAM);
+	memranges_add_resources(&memory_map, IORESOURCE_RESERVE,
+				IORESOURCE_RESERVE, BM_MEM_RESERVED);
+	memranges_add_resources(&memory_map, IORESOURCE_SOFT_RESERVE,
+				IORESOURCE_SOFT_RESERVE, BM_MEM_RESERVED);
 
 	if (ENV_X86_32)
 		init_pae_pagetables(&pae_page_tables);
@@ -766,15 +750,17 @@ void efi_parse_capsules(void)
 			 (uintptr_t)cbmem_current + cbmem_size - cbmem_future_base,
 			 BM_MEM_RESERVED);
 
-	coalesce_buffer = pick_buffer(total_data_size);
-	if (coalesce_buffer.base == 0) {
+	struct memory_range candidate = pick_buffer(total_data_size);
+	if (candidate.base == 0) {
 		printk(BIOS_ERR,
 		       "capsules: failed to find a buffer (%#llx bytes) for coalesced UEFI capsules.\n",
 		       total_data_size);
 	} else {
 		printk(BIOS_DEBUG, "capsules: coalescing capsules data @ %#010x.\n",
-		       coalesce_buffer.base);
-		coalesce_capsules(block_chain, (void *)(uintptr_t)coalesce_buffer.base);
+		       candidate.base);
+		coalesce_capsules(block_chain, (void *)(uintptr_t)candidate.base);
+		if (uefi_capsule_count > 0)
+			coalesce_buffer = candidate;
 	}
 	if (uefi_capsule_count > 0)
 		set_boot_mode(LB_BOOT_MODE_FLASH_UPDATE);
@@ -803,11 +789,27 @@ void lb_efi_capsules(struct lb_header *header)
 
 void efi_add_capsules_to_bootmem(void)
 {
-	if (coalesce_buffer.len != 0) {
-		printk(BIOS_INFO, "capsules: reserving capsules data @ %#010x.\n",
-		       coalesce_buffer.base);
-		bootmem_add_range(coalesce_buffer.base, coalesce_buffer.len, BM_MEM_RESERVED);
+	uintptr_t base;
+	size_t size;
+
+	if (efi_capsule_coalesce_span(&base, &size)) {
+		printk(BIOS_INFO, "capsules: reserving capsules data @ %#010lx.\n",
+		       (unsigned long)base);
+		bootmem_add_range(base, size, BM_MEM_RESERVED);
 	}
+}
+
+bool efi_capsule_coalesce_span(uintptr_t *base, size_t *size)
+{
+	if (base == NULL || size == NULL || coalesce_buffer.base == 0 ||
+	    coalesce_buffer.len == 0 || !IS_ALIGNED(coalesce_buffer.base, 4 * KiB) ||
+	    !IS_ALIGNED(coalesce_buffer.len, 4 * KiB) ||
+	    coalesce_buffer.base > UINTPTR_MAX - coalesce_buffer.len)
+		return false;
+
+	*base = coalesce_buffer.base;
+	*size = coalesce_buffer.len;
+	return true;
 }
 
 /*

--- a/src/drivers/efi/capsules.h
+++ b/src/drivers/efi/capsules.h
@@ -9,11 +9,20 @@ void efi_parse_capsules(void);
 
 void efi_add_capsules_to_bootmem(void);
 
+bool efi_capsule_coalesce_span(uintptr_t *base, size_t *size);
+
 #else
 
 static inline void efi_parse_capsules(void) { }
 
 static inline void efi_add_capsules_to_bootmem(void) { }
+
+static inline bool efi_capsule_coalesce_span(uintptr_t *base, size_t *size)
+{
+	(void)base;
+	(void)size;
+	return false;
+}
 
 #endif
 

--- a/src/security/memory/memory_clear.c
+++ b/src/security/memory/memory_clear.c
@@ -86,6 +86,10 @@ static void clear_memory(void *unused)
 	if (cbmem_get_region(&baseptr, &size))
 		die("Could not find cbmem region");
 	memranges_insert(&mem, (uintptr_t)baseptr, size, BM_MEM_TABLE);
+	uintptr_t capsule_base;
+	size_t capsule_size;
+	if (efi_capsule_coalesce_span(&capsule_base, &capsule_size))
+		memranges_insert(&mem, capsule_base, capsule_size, BM_MEM_RESERVED);
 
 	if (ENV_X86) {
 		/* Find space for PAE enabled memset */

--- a/tests/acpi/Makefile.mk
+++ b/tests/acpi/Makefile.mk
@@ -1,7 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 tests-y += acpigen-test
+tests-y += qemu-rsdp-test
 
 acpigen-test-srcs += tests/acpi/acpigen-test.c
 acpigen-test-srcs += src/acpi/acpigen.c
 acpigen-test-srcs += tests/stubs/console.c
+
+qemu-rsdp-test-srcs += tests/acpi/qemu_rsdp_standalone_test.c
+qemu-rsdp-test-stage := ramstage
+qemu-rsdp-test-no_test_framework := 1
+
+.PHONY: qemu-rsdp-source-test
+qemu-rsdp-source-test:
+	$(Q)tests/acpi/qemu_rsdp_source_test.sh
+
+run-tests/acpi/qemu-rsdp-test: qemu-rsdp-source-test

--- a/tests/acpi/qemu_rsdp_source_test.sh
+++ b/tests/acpi/qemu_rsdp_source_test.sh
@@ -11,6 +11,8 @@ check_source()
 	source_file=$1
 	test "$(grep -c 'if (acpi_qemu_rsdp_needs_xsdt(rsdp))' "$source_file")" -eq 1 ||
 		return 1
+	test "$(grep -c 'acpi_qemu_clear_xsdt(xsdt);' "$source_file")" -eq 1 ||
+		return 1
 	if grep -q 'if (rsdp->xsdt_address' "$source_file"; then
 		return 1
 	fi
@@ -26,6 +28,11 @@ fi
 sed '/if (acpi_qemu_rsdp_needs_xsdt(rsdp))/d' "$root/src/acpi/acpi.c" \
 	>"$temporary/missing-helper.c"
 if check_source "$temporary/missing-helper.c"; then
+	exit 1
+fi
+sed '/acpi_qemu_clear_xsdt(xsdt);/d' "$root/src/acpi/acpi.c" \
+	>"$temporary/missing-clear.c"
+if check_source "$temporary/missing-clear.c"; then
 	exit 1
 fi
 printf '%s\n' 'qemu RSDP source contract: PASS'

--- a/tests/acpi/qemu_rsdp_source_test.sh
+++ b/tests/acpi/qemu_rsdp_source_test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+temporary=$(mktemp -d)
+trap 'rm -rf "$temporary"' EXIT HUP INT TERM
+
+check_source()
+{
+	source_file=$1
+	test "$(grep -c 'if (acpi_qemu_rsdp_needs_xsdt(rsdp))' "$source_file")" -eq 1 ||
+		return 1
+	if grep -q 'if (rsdp->xsdt_address' "$source_file"; then
+		return 1
+	fi
+	return 0
+}
+
+check_source "$root/src/acpi/acpi.c"
+sed 's/acpi_qemu_rsdp_needs_xsdt(rsdp)/rsdp->xsdt_address == 0/' \
+	"$root/src/acpi/acpi.c" >"$temporary/direct-field.c"
+if check_source "$temporary/direct-field.c"; then
+	exit 1
+fi
+sed '/if (acpi_qemu_rsdp_needs_xsdt(rsdp))/d' "$root/src/acpi/acpi.c" \
+	>"$temporary/missing-helper.c"
+if check_source "$temporary/missing-helper.c"; then
+	exit 1
+fi
+printf '%s\n' 'qemu RSDP source contract: PASS'

--- a/tests/acpi/qemu_rsdp_standalone_test.c
+++ b/tests/acpi/qemu_rsdp_standalone_test.c
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include "../../src/acpi/qemu_rsdp.h"
+
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static int expect(bool condition, const char *message)
+{
+	if (condition)
+		return 0;
+	(void)message;
+	return 1;
+}
+
+int main(void)
+{
+	long page_size = sysconf(_SC_PAGESIZE);
+	unsigned char *mapping;
+	acpi_rsdp_t rsdp;
+	acpi_rsdp_t *short_rsdp;
+	int failures = 0;
+
+	mapping = mmap(NULL, (size_t)page_size * 2U, PROT_READ | PROT_WRITE,
+		MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (mapping == MAP_FAILED)
+		return 1;
+	if (mprotect(mapping + page_size, page_size, PROT_NONE) != 0)
+		return 1;
+	short_rsdp = (acpi_rsdp_t *)(void *)(mapping + page_size - 20U);
+	memset(short_rsdp, 0, 20U);
+	short_rsdp->revision = 0;
+	failures += expect(acpi_qemu_rsdp_needs_xsdt(short_rsdp),
+		"revision 0 read beyond its 20-byte object");
+	short_rsdp->revision = 1;
+	failures += expect(acpi_qemu_rsdp_needs_xsdt(short_rsdp),
+		"revision 1 read beyond its 20-byte object");
+	rsdp = (acpi_rsdp_t){0};
+	rsdp.revision = 2;
+	rsdp.length = sizeof(rsdp);
+	rsdp.xsdt_address = 0x12345000U;
+	failures += expect(!acpi_qemu_rsdp_needs_xsdt(&rsdp),
+		"valid ACPI 2.0 XSDT was rebuilt");
+	rsdp.length = sizeof(rsdp) - 1U;
+	failures += expect(acpi_qemu_rsdp_needs_xsdt(&rsdp),
+		"short ACPI 2.0 RSDP was reused");
+	rsdp.length = sizeof(rsdp);
+	rsdp.xsdt_address = 0;
+	failures += expect(acpi_qemu_rsdp_needs_xsdt(&rsdp),
+		"ACPI 2.0 RSDP without XSDT was reused");
+	(void)munmap(mapping, (size_t)page_size * 2U);
+	return failures != 0;
+}

--- a/tests/acpi/qemu_rsdp_standalone_test.c
+++ b/tests/acpi/qemu_rsdp_standalone_test.c
@@ -20,6 +20,7 @@ int main(void)
 	unsigned char *mapping;
 	acpi_rsdp_t rsdp;
 	acpi_rsdp_t *short_rsdp;
+	acpi_xsdt_t xsdt;
 	int failures = 0;
 
 	mapping = mmap(NULL, (size_t)page_size * 2U, PROT_READ | PROT_WRITE,
@@ -49,6 +50,14 @@ int main(void)
 	rsdp.xsdt_address = 0;
 	failures += expect(acpi_qemu_rsdp_needs_xsdt(&rsdp),
 		"ACPI 2.0 RSDP without XSDT was reused");
+	memset(&xsdt, 0xff, sizeof(xsdt));
+	acpi_qemu_clear_xsdt(&xsdt);
+	failures += expect(xsdt.header.length == 0 && xsdt.entry[0] == 0,
+		"fresh XSDT retained prior entries");
+	xsdt.entry[0] = 0x12345000U;
+	acpi_qemu_clear_xsdt(&xsdt);
+	failures += expect(xsdt.entry[0] == 0,
+		"second XSDT construction retained its first entry");
 	(void)munmap(mapping, (size_t)page_size * 2U);
 	return failures != 0;
 }

--- a/tests/lib/Makefile.mk
+++ b/tests/lib/Makefile.mk
@@ -24,6 +24,7 @@ tests-y += malloc-test
 tests-y += memmove-test
 tests-y += crc_byte-test
 tests-y += memrange-test
+tests-y += capsule-buffer-test
 tests-y += uuid-test
 tests-y += bootmem-test
 tests-y += dimm_info_util-test
@@ -136,6 +137,18 @@ memrange-test-srcs += tests/lib/memrange-test.c
 memrange-test-srcs += src/lib/memrange.c
 memrange-test-srcs += tests/stubs/console.c
 memrange-test-srcs += src/device/device_util.c
+
+capsule-buffer-test-srcs += tests/lib/capsule-buffer-test.c
+capsule-buffer-test-srcs += src/lib/memrange.c
+capsule-buffer-test-srcs += tests/stubs/console.c
+capsule-buffer-test-srcs += src/device/device_util.c
+capsule-buffer-test-no_test_framework := 1
+
+.PHONY: capsule-buffer-source-test
+capsule-buffer-source-test:
+	$(Q)tests/lib/capsule-buffer-source-test.sh
+
+run-tests/lib/capsule-buffer-test: capsule-buffer-source-test
 
 uuid-test-srcs += tests/lib/uuid-test.c
 uuid-test-srcs += src/lib/hexstrtobin.c

--- a/tests/lib/capsule-buffer-source-test.sh
+++ b/tests/lib/capsule-buffer-source-test.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd -P)
+capsules=${CAPSULES_SOURCE:-$root/src/drivers/efi/capsules.c}
+clear=${MEMORY_CLEAR_SOURCE:-$root/src/security/memory/memory_clear.c}
+
+check()
+{
+	python3 - "$capsules" "$clear" <<'PY'
+import pathlib, re, sys
+c = pathlib.Path(sys.argv[1]).read_text()
+m = pathlib.Path(sys.argv[2]).read_text()
+assert c.count("static struct memory_range coalesce_buffer;") == 1
+assert not re.search(r"extern[^;]*coalesce_buffer", c + m)
+publication = ("coalesce_capsules(block_chain, (void *)(uintptr_t)candidate.base);\n"
+               "\t\tif (uefi_capsule_count > 0)\n"
+               "\t\t\tcoalesce_buffer = candidate;")
+assert c.count(publication) == 1
+assert c.count("coalesce_buffer = candidate;") == 1
+assert c.count("efi_capsule_coalesce_span(&base, &size)") == 1
+assert m.count("efi_capsule_coalesce_span(&capsule_base, &capsule_size)") == 1
+assert m.index("efi_capsule_coalesce_span(&capsule_base, &capsule_size)") < m.index(
+    "memranges_each_entry(r, &mem)")
+assert c.count("coalesce_buffer.") == 8
+PY
+}
+
+check
+[ "${CAPSULE_SOURCE_CHECK_ONLY:-0}" = 1 ] && exit 0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+cp "$capsules" "$tmp/capsules.c"
+cp "$clear" "$tmp/memory_clear.c"
+capsules=$tmp/capsules.c MEMORY_CLEAR_SOURCE=$tmp/memory_clear.c
+
+mutate_reject()
+{
+	if CAPSULES_SOURCE=$capsules MEMORY_CLEAR_SOURCE=$MEMORY_CLEAR_SOURCE \
+		CAPSULE_SOURCE_CHECK_ONLY=1 \
+		"$0" >/dev/null 2>&1; then
+		echo "source contract accepted mutation: $1" >&2
+		exit 1
+	fi
+}
+
+python3 - "$capsules" <<'PY'
+import pathlib, sys
+p=pathlib.Path(sys.argv[1]); s=p.read_text()
+p.write_text(s.replace("if (uefi_capsule_count > 0)", "if (true)", 1))
+PY
+mutate_reject unguarded-publication
+cp "$root/src/drivers/efi/capsules.c" "$capsules"
+python3 - "$MEMORY_CLEAR_SOURCE" <<'PY'
+import pathlib, sys
+p=pathlib.Path(sys.argv[1]); s=p.read_text()
+p.write_text(s.replace("efi_capsule_coalesce_span(&capsule_base, &capsule_size)",
+                       "false", 1))
+PY
+mutate_reject missing-pre-clear-consumer
+cp "$root/src/security/memory/memory_clear.c" "$MEMORY_CLEAR_SOURCE"
+python3 - "$capsules" <<'PY'
+import pathlib, sys
+p=pathlib.Path(sys.argv[1]); s=p.read_text()
+p.write_text(s.replace("efi_capsule_coalesce_span(&base, &size)", "false", 1))
+PY
+mutate_reject missing-bootmem-consumer

--- a/tests/lib/capsule-buffer-test.c
+++ b/tests/lib/capsule-buffer-test.c
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <drivers/efi/capsule_buffer.h>
+#include <string.h>
+
+#define CHECK(condition) do { if (!(condition)) return 1; } while (0)
+
+static void clear_ram(uint8_t *arena, struct memranges *ranges)
+{
+	const struct range_entry *entry;
+
+	memranges_each_entry(entry, ranges) {
+		if (range_entry_tag(entry) == BM_MEM_RAM)
+			memset(arena + range_entry_base(entry), 0,
+			       range_entry_size(entry));
+	}
+}
+
+static int test_capsule_buffer_survives_clear(void)
+{
+	struct range_entry storage[16];
+	struct memranges ranges;
+	uint8_t arena[0x10000];
+	uint64_t base;
+	uint64_t size;
+
+	memset(arena, 0xa5, sizeof(arena));
+	memranges_init_empty(&ranges, storage, ARRAY_SIZE(storage));
+	memranges_insert(&ranges, 0x1000, 0xf000, BM_MEM_RAM);
+	memranges_insert(&ranges, 0xf000, 0x1000, BM_MEM_RESERVED);
+	CHECK(efi_capsule_pick_buffer(&ranges, 481, &base, &size));
+	CHECK(base == 0xe000);
+	CHECK(size == 0x1000);
+	memranges_insert(&ranges, base, size, BM_MEM_RESERVED);
+	clear_ram(arena, &ranges);
+	CHECK(arena[base] == 0xa5);
+	CHECK(arena[base + 480] == 0xa5);
+	CHECK(arena[base - 1] == 0);
+	CHECK(arena[0xf000] == 0xa5);
+	memranges_teardown(&ranges);
+	return 0;
+}
+
+static int test_capsule_buffer_contract(void)
+{
+	struct range_entry storage[16];
+	struct memranges ranges;
+	uint64_t base = 0x55;
+	uint64_t size = 0x66;
+	uint64_t again_base;
+	uint64_t again_size;
+
+	memranges_init_empty(&ranges, storage, ARRAY_SIZE(storage));
+	memranges_insert(&ranges, 0x1000, 0x8000, BM_MEM_RAM);
+	CHECK(!efi_capsule_pick_buffer(&ranges, 0, &base, &size));
+	CHECK(base == 0x55);
+	CHECK(size == 0x66);
+	CHECK(!efi_capsule_pick_buffer(&ranges, UINT64_MAX, &base, &size));
+	memranges_insert(&ranges, 0x8000, 0x1000, BM_MEM_RESERVED);
+	CHECK(efi_capsule_pick_buffer(&ranges, 1, &base, &size));
+	CHECK(base == 0x7000);
+	CHECK(size == 0x1000);
+	CHECK(efi_capsule_pick_buffer(&ranges, 1, &again_base, &again_size));
+	CHECK(again_base == base);
+	CHECK(again_size == size);
+	memranges_insert(&ranges, 0x1000, 0x7000, BM_MEM_RESERVED);
+	CHECK(!efi_capsule_pick_buffer(&ranges, 1, &base, &size));
+	memranges_teardown(&ranges);
+	return 0;
+}
+
+int main(void)
+{
+	if (test_capsule_buffer_survives_clear() || test_capsule_buffer_contract())
+		return 1;
+	return 0;
+}


### PR DESCRIPTION
## Summary
- rebuild the QEMU XSDT from a versioned RSDP
- clear synthesized XSDT entries before reuse
- preserve coalesced EFI capsules through memory clearing

## Validation
- final QEMU replay: 28/28 acceptance lanes passed
- interrupted-capsule and runtime-service lanes passed
- tested ROM SHA-256: `d6b734dd672e8c839f25add50b2cd8f39c82f280cab2727a5ade546e676abff1`
- independent opposing audit: PASS

This is a strict linear continuation of the Q35 SPI-console PR.