### PR TITLE
soc/intel: use the available GPE status helper

### DIFF
--- a/src/soc/intel/common/block/smm/smihandler.c
+++ b/src/soc/intel/common/block/smm/smihandler.c
@@ -172,7 +172,7 @@ void smihandler_southbridge_sleep(
 	}
 
 	/* Clear pending GPE events, preserving an armed WADT if needed. */
-	pmc_clear_all_gpe_status_except(gpe_preserve);
+	pmc_clear_gpe_status(gpe_preserve);
 #else
 	/* Clear pending GPE events. */
 	pmc_clear_all_gpe_status();


### PR DESCRIPTION
## Summary
Uses the existing PMC helper when preserving armed WADT GPE status, restoring the SMM build on this lineage.

## Validation
- full StarLite Mk V ROM build passed
- CDK2 coreboot, FV, and ELF checks passed
- coreboot serial, CDK2 serial, CBMEM, timestamps, diagnostics, and SPI console resolve enabled
- final ROM SHA-256: fff442031129e9aea449794dce58a95d7aadacbf63a3385754b54fbcf0505e20

This is a strict linear continuation of the preceding PR.