### PR TITLE
mb/starlabs/starbook: Correct RPL-U I/O board USB3 port

### DIFF
--- a/src/mainboard/starlabs/starbook/variants/rpl_u/devicetree.cb
+++ b/src/mainboard/starlabs/starbook/variants/rpl_u/devicetree.cb
@@ -129,12 +129,9 @@ chip soc/intel/alderlake
 			register "usb2_ports[1]"		= "USB2_PORT_TYPE_C(OC_SKIP)"
 			register "tcss_ports[1]"		= "TCSS_PORT_CC1(OC_SKIP)"
 
-			# Right USB 3.0 Hub (PCH USB3 P3)
-			# PCH USB3 P3: 2.43"-2.77" (2430-2768 mils);
-			# GL3510 paths: 1.68"-1.72" upstream and
-			# 1.96"-3.48" downstream (1676-3477 mils).
+			# Right USB 3.0 Hub (JDB1: USB2 P7 / PCH USB3 P1)
 			register "usb2_ports[6]"		= "USB2_PORT_SHORT(OC_SKIP)"
-			register "usb3_ports[2]"		= "USB3_PORT_DEFAULT(OC_SKIP)"
+			register "usb3_ports[0]"		= "USB3_PORT_DEFAULT(OC_SKIP)"
 
 			# Internal Webcam
 			# USB2 trace length not covered by the supplied USB3 sheets.
@@ -195,7 +192,7 @@ chip soc/intel/alderlake
 						register "type"			= "UPC_TYPE_HUB"
 						register "use_custom_pld"	= "true"
 						register "custom_pld"		= "ACPI_PLD_TYPE_C(RIGHT, CENTER, ACPI_PLD_GROUP(0, 2))"
-						device ref usb3_port3 on
+						device ref usb3_port1 on
 							chip drivers/usb/hub
 								register "name"		= ""GL3510""
 								register "desc"		= ""Right USB 3.0 Hub""
@@ -302,7 +299,7 @@ chip soc/intel/alderlake
 					# Right USB Type-C via the right GL3510 hub.
 					chip drivers/intel/pmc_mux/conn
 						use usb2_port7 as usb2_port
-						use usb3_port3 as usb3_port
+						use usb3_port1 as usb3_port
 						device generic 2 alias conn2 on end
 					end
 				end


### PR DESCRIPTION
JDB1 carries USB2 P7 and USB3 P1. The existing configuration enables P3,
which instead goes to the HDMI daughterboard connector.

Move the USB3 enable and matching ACPI/PMC references to P1. Leave the
separate daughterboard topology questions out of this change.

Tested on StarBook RPL-U: applied through a COREBOOT-only capsule and booted
Fedora. The hub SuperSpeed companion appeared on P1 and the USB boot drive
enumerated at 5 Gb/s instead of 480 Mb/s. RTC-woken S3 retained the USB root
filesystem and passed a write/read checksum check.

A separate edk2 downstream-hub reset problem required a replug to boot after
some resets. StarLabsLtd/edk2#21 addresses that enumeration issue. The earlier
S3 network loss included an AX211 firmware crash, not a demonstrated loss of
the USB root filesystem. Neither is claimed fixed by this port-map change.

Stacked on #64.
